### PR TITLE
Update GPy version to 1.9.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,9 @@ before_install: |
     pip -V
     if [ $PYTHON == 3.4.4 ] || [ $PYTHON == 3.5.1 ]; then
       # GPy requires numpy during setup for Python versions less than 3.6
-      pip install numpy
+      # pip install numpy
+      echo $PYTHON
+      pip freeze
     fi
   fi
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install: |
     # Confirm versions
     python --version
     pip -V
-    if [[$PYTHON == '3.4.4'] || [$PYTHON == '3.5.1']]; then
+    if [ $PYTHON == 3.4.4 ] || [ $PYTHON == 3.5.1 ]; then
       # GPy requires numpy during setup for Python versions less than 3.6
       pip install numpy
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,10 @@ before_install: |
     # Confirm versions
     python --version
     pip -V
-    # Remove this line after GPy 1.9.3
-    pip install numpy
+    if [[$PYTHON == '3.4.4'] || [$PYTHON == '3.5.1']]; then
+      # GPy requires numpy during setup for Python versions less than 3.6
+      pip install numpy
+    fi
   fi
 install:
   - pip install --upgrade pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,9 @@ before_install: |
     # Confirm versions
     python --version
     pip -V
-    if [ $PYTHON == 3.4.4 ] || [ $PYTHON == 3.5.1 ]; then
-      # GPy requires numpy during setup for Python versions less than 3.6
-      # pip install numpy
-      echo $PYTHON
-      pip freeze
+    if [ $PYTHON == 3.4.4 ]; then
+      # GPy requires numpy during setup for Python versions less than 3.5
+      pip install numpy
     fi
   fi
 install:

--- a/README.md
+++ b/README.md
@@ -44,9 +44,11 @@ predictions = repurposer.predict_label(test_iterator)
 
 ## Installation
 * __Dependencies:__
-Primary dependencies are MXNet >=1.2 and GPy >= 1.9.3. See [requirements](requirements.txt).
+Primary dependencies are MXNet >=1.2 and GPy >= 1.9.5. See [requirements](requirements.txt).
 * __Supported architectures / versions:__
-Tested on Python 3.4+ on MacOS and Amazon Linux.
+Python 3.6+ on MacOS and Amazon Linux. 
+
+    Also tested on Python 3.4 and 3.5. Kindly note that for these Python versions, NumPy must be pre-installed for GPy (dependency of Xfer) to work.
 
 - __Install with pip:__
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ mxnet==1.2.0
 numpy==1.14.5
 scikit-learn==0.19.2
 matplotlib==2.2.2
-GPy==1.9.2
+GPy==1.9.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,1 @@
-mxnet==1.2.0
-numpy==1.14.5
-scikit-learn==0.19.2
-matplotlib==2.2.2
-GPy==1.9.5
+-e .  # Installs dependencies from ./setup.py, and the package itself, in editable mode.

--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,8 @@ with open('README.md', 'r') as fh:
 
 
 requires = [
-    'numpy>=1.12.1',
     'mxnet==1.2.0',
+    'numpy==1.15.0',
     'scikit-learn==0.19.2',
     'matplotlib==2.2.2',
     'GPy==1.9.5'

--- a/setup.py
+++ b/setup.py
@@ -20,10 +20,11 @@ with open('README.md', 'r') as fh:
 
 
 requires = [
+    'numpy>=1.12.1',
     'mxnet==1.2.0',
     'scikit-learn==0.19.2',
     'matplotlib==2.2.2',
-    'GPy==1.9.2'
+    'GPy==1.9.5'
 ]
 
 

--- a/tests/integration/test_workflow.py
+++ b/tests/integration/test_workflow.py
@@ -60,8 +60,6 @@ class WorkflowTestCase(TestCase):
         """
         if self.__class__ == WorkflowTestCase:  # base class
             return
-        if self.__class__ == GpWorkflowTestCase:  # Remove after release of GPy 1.9.3
-            return
         # remove any old saved repurposer files
         RepurposerTestUtils._remove_files_with_prefix(self.save_name)
 
@@ -95,8 +93,6 @@ class WorkflowTestCase(TestCase):
     def test_load_pre_saved_repurposer(self):
         """ Test case to check for backward compatibility of deserialization """
         if self.__class__ == WorkflowTestCase:  # base class
-            return
-        if self.__class__ == GpWorkflowTestCase:  # Remove after release of GPy 1.9.3
             return
         # Load pre-saved repurposer from file
         repurposer_file_prefix = self.pre_saved_prefix + self.__class__.__name__

--- a/tests/unit/test_gp_repurposer.py
+++ b/tests/unit/test_gp_repurposer.py
@@ -110,6 +110,7 @@ class GpRepurposerTestCase(MetaModelRepurposerTestCase):
         mock_model_handler.return_value = RepurposerTestUtils.get_mock_model_handler_object()
         mock_model_handler.return_value.get_layer_output.return_value = {'l1': self.train_features}, self.train_labels
         gp_repurposer = GpRepurposer(self.source_model, self.source_model_layers)
+        gp_repurposer.NUM_INDUCING_SPARSE_GP = 5  # To speed-up unit test running time
         self._run_common_repurposer_tests(gp_repurposer)
 
     def _validate_trained_model(self, target_model):

--- a/tests/unit/test_gp_repurposer.py
+++ b/tests/unit/test_gp_repurposer.py
@@ -132,7 +132,6 @@ class GpRepurposerTestCase(MetaModelRepurposerTestCase):
         self._test_gp_serialisation(sparse_gp=False, multiple_kernels=False)
 
     def _test_gp_serialisation(self, sparse_gp, multiple_kernels):
-        return  # Remove this line on release of GPy 1.9.3 with serialization support
         gp_repurposer = GpRepurposer(self.source_model, self.source_model_layers, apply_l2_norm=True)
         num_inducing = gp_repurposer.NUM_INDUCING_SPARSE_GP
 

--- a/tests/unit/test_meta_model_repurposer.py
+++ b/tests/unit/test_meta_model_repurposer.py
@@ -167,12 +167,17 @@ class MetaModelRepurposerTestCase(TestCase):
                                                          meta_model_data.feature_indices_per_layer)
 
     def test_serialisation(self, mock_model_handler):
-        if self.repurposer_class in [MetaModelRepurposer, GpRepurposer]:
+        if self.repurposer_class == MetaModelRepurposer:  # base class
             return
         self._test_save_load_repurposed_model(mock_model_handler, save_source_model=True)
         self._test_save_load_repurposed_model(mock_model_handler, save_source_model=False)
 
     def _test_save_load_repurposed_model(self, mock_model_handler, save_source_model):
+        # To speed-up unit test running time. Accuracy is validated in integration tests.
+        num_train_points = 10
+        self.train_features = self.train_features[:num_train_points]
+        self.train_labels = self.train_labels[:num_train_points]
+
         mock_model_handler.return_value = RepurposerTestUtils.get_mock_model_handler_object()
         file_path = 'test_serialisation'
         RepurposerTestUtils._remove_files_with_prefix(file_path)

--- a/xfer/gp_repurposer.py
+++ b/xfer/gp_repurposer.py
@@ -241,7 +241,6 @@ class GpRepurposer(MetaModelRepurposer):
         :param str file_prefix: Prefix of file path to save the serialized repurposer to.
         :return: None
         """
-        raise NotImplementedError('This feature will be enabled after the release of GPy 1.9.3')
         # Get constructor params. This will be used to recreate repurposer object in deserialization flow.
         output_dict = {repurposer_keys.PARAMS: self.get_params()}
 


### PR DESCRIPTION
Update GPy version to 1.9.5 in requirements file.
Enable serialization tests for GP Repurposer.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
