### PR TITLE
Replace ftp link in README with http link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [Contribution Guide](CONTRIBUTING.md)
 
 #### What is Xfer?
-Xfer is a library that allows quick and easy transfer of knowledge<sup>[1](ftp://ftp.cs.wisc.edu/machine-learning/shavlik-group/torrey.handbook09.pdf),[2](http://cs231n.github.io/transfer-learning/),[3](https://papers.nips.cc/paper/5347-how-transferable-are-features-in-deep-neural-networks.pdf)</sup> stored in deep neural networks implemented in [MXNet](https://mxnet.incubator.apache.org/). Xfer can be used with data of arbitrary numeric format, and can be applied to the common cases of image or text data.
+Xfer is a library that allows quick and easy transfer of knowledge<sup>[1](http://pages.cs.wisc.edu/%7Eshavlik/abstracts/torrey.handbook09.abstract.html),[2](http://cs231n.github.io/transfer-learning/),[3](https://papers.nips.cc/paper/5347-how-transferable-are-features-in-deep-neural-networks.pdf)</sup> stored in deep neural networks implemented in [MXNet](https://mxnet.incubator.apache.org/). Xfer can be used with data of arbitrary numeric format, and can be applied to the common cases of image or text data.
 
 Xfer can be used as a pipeline that spans from extracting features to training a repurposer. The repurposer is then an object that carries out predictions in the target task.
 


### PR DESCRIPTION
Issue #9 

ReadMe file had an ftp link to a transfer learning paper and it does not render on GitHub. Replaced this ftp link with its corresponding http link.  

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
