### PR TITLE
Remove deprecated param from custom repurposer demo

### DIFF
--- a/docs/demos/xfer-custom-repurposers.ipynb
+++ b/docs/demos/xfer-custom-repurposers.ipynb
@@ -21,7 +21,9 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "import warnings\n",
@@ -341,18 +343,18 @@
      "text": [
       "             precision    recall  f1-score   support\n",
       "\n",
-      "          0       0.86      0.95      0.90        20\n",
-      "          1       0.63      0.85      0.72        20\n",
-      "          2       0.79      0.75      0.77        20\n",
-      "          3       0.52      0.80      0.63        20\n",
-      "          4       0.78      0.70      0.74        20\n",
-      "          5       0.82      0.90      0.86        20\n",
-      "          6       1.00      0.30      0.46        20\n",
-      "          7       0.86      0.90      0.88        20\n",
+      "          0       0.50      0.80      0.62        20\n",
+      "          1       0.78      0.90      0.84        20\n",
+      "          2       0.70      0.70      0.70        20\n",
+      "          3       0.78      0.70      0.74        20\n",
+      "          4       0.78      0.90      0.84        20\n",
+      "          5       0.85      0.85      0.85        20\n",
+      "          6       0.64      0.80      0.71        20\n",
+      "          7       0.64      0.45      0.53        20\n",
       "          8       0.75      0.75      0.75        20\n",
-      "          9       0.64      0.45      0.53        20\n",
+      "          9       1.00      0.25      0.40        20\n",
       "\n",
-      "avg / total       0.76      0.73      0.72       200\n",
+      "avg / total       0.74      0.71      0.70       200\n",
       "\n"
      ]
     }
@@ -386,8 +388,8 @@
    "source": [
     "class Add2FullyConnectedRepurposer(xfer.NeuralNetworkRepurposer):\n",
     "    def __init__(self, source_model: mx.mod.Module, transfer_layer_name, num_nodes, target_class_count,\n",
-    "                 context_function=mx.context.cpu, num_devices=1, learning_rate=1e-3, batch_size=64, num_epochs=5):\n",
-    "        super().__init__(source_model, context_function, num_devices, learning_rate, batch_size, num_epochs)\n",
+    "                 context_function=mx.context.cpu, num_devices=1, batch_size=64, num_epochs=5):\n",
+    "        super().__init__(source_model, context_function, num_devices, batch_size, num_epochs)\n",
     "        \n",
     "        # initialse parameters\n",
     "        self.transfer_layer_name = transfer_layer_name\n",
@@ -483,18 +485,18 @@
      "text": [
       "             precision    recall  f1-score   support\n",
       "\n",
-      "          0       1.00      0.80      0.89        20\n",
-      "          1       1.00      0.80      0.89        20\n",
-      "          2       0.95      1.00      0.98        20\n",
-      "          3       0.95      1.00      0.98        20\n",
-      "          4       1.00      1.00      1.00        20\n",
-      "          5       1.00      0.95      0.97        20\n",
-      "          6       0.80      1.00      0.89        20\n",
-      "          7       0.95      0.95      0.95        20\n",
-      "          8       0.91      1.00      0.95        20\n",
-      "          9       0.95      0.95      0.95        20\n",
+      "          0       0.91      1.00      0.95        20\n",
+      "          1       1.00      0.95      0.97        20\n",
+      "          2       1.00      0.55      0.71        20\n",
+      "          3       1.00      0.85      0.92        20\n",
+      "          4       0.95      1.00      0.98        20\n",
+      "          5       1.00      0.80      0.89        20\n",
+      "          6       1.00      0.85      0.92        20\n",
+      "          7       0.70      0.95      0.81        20\n",
+      "          8       0.62      1.00      0.77        20\n",
+      "          9       1.00      0.90      0.95        20\n",
       "\n",
-      "avg / total       0.95      0.94      0.94       200\n",
+      "avg / total       0.92      0.89      0.89       200\n",
       "\n"
      ]
     }
@@ -506,9 +508,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:xfer_env]",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda-env-xfer_env-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -520,7 +522,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.4"
+   "version": "3.6.3"
   }
  },
  "nbformat": 4,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.5
+current_version = 0.1.6
 tag = True
 commit = True
 

--- a/xfer/__version__.py
+++ b/xfer/__version__.py
@@ -11,4 +11,4 @@
 #   express or implied. See the License for the specific language governing
 #   permissions and limitations under the License.
 # ==============================================================================
-__version__ = '0.1.5'
+__version__ = '0.1.6'


### PR DESCRIPTION
Learning_rate parameter is no longer part of base neural network repurposer and hence needs to be removed from the custom repurposer that inherits from this base class. Default learning rate as part of optimizer_params is used instead.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
