### PR TITLE
GPy backend issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,8 @@ install:
   - pip install --upgrade pip
   - pip install -r requirements.txt
   - pip install -r test_requirements.txt
+  # work around issues with GPy and GPyOpt setting matplotlib backend
+  - "echo 'backend: Agg' > matplotlibrc"
   - pip freeze
 script:
   - flake8

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,6 +100,17 @@ pytest tests/unit
 pytest tests/integration
 ```
 
+#### Troubleshooting
+When running the tests on OSX, you may get this error when running the GpRepurposer.
+```
+from matplotlib.backends import _macosx
+RuntimeError: Python is not installed as a framework. The Mac OS X backend will not be able to function correctly if Python is not installed as a framework. See the Python documentation for more information on installing Python as a framework on Mac OS X. Please either reinstall Python as a framework, or try one of the other backends. If you are using (Ana)Conda please install python.app and replace the use of 'python' with 'pythonw'. See 'Working with Matplotlib on OSX' in the Matplotlib FAQ for more information.
+```
+This can be fixed by running the following command from the root directory of the repo.
+```
+echo 'backend: Agg' > matplotlibrc
+```
+
 ### Generating docs
 Documentation contributions are much appreciated! If you see something incorrect or poorly explained, please fix it and send the update!
 

--- a/xfer/__init__.py
+++ b/xfer/__init__.py
@@ -11,10 +11,6 @@
 #   express or implied. See the License for the specific language governing
 #   permissions and limitations under the License.
 # ==============================================================================
-# matplotlib is loaded in GPy initialization and if a backend('Agg') is not set, loading fails in mac osx
-import matplotlib
-matplotlib.use('Agg')
-
 # import repurposer base classes
 from .repurposer import Repurposer  # noqa: F401
 from .meta_model_repurposer import MetaModelRepurposer  # noqa: F401

--- a/xfer/gp_repurposer.py
+++ b/xfer/gp_repurposer.py
@@ -13,7 +13,6 @@
 # ==============================================================================
 import mxnet as mx
 import numpy as np
-import GPy
 from sklearn.preprocessing import LabelBinarizer, Normalizer
 
 from .meta_model_repurposer import MetaModelRepurposer
@@ -109,6 +108,8 @@ class GpRepurposer(MetaModelRepurposer):
         return models
 
     def _train_model_for_binary_label(self, features, binary_label, kernel, do_sparse_gp):
+        # GPy is imported here in order to avoid importing it during 'import xfer'
+        import GPy
         # Train a GPy model for binary classification with given features and kernel
         if do_sparse_gp:
             model = GPy.models.SparseGPClassification(X=features, Y=binary_label, kernel=kernel,
@@ -131,10 +132,13 @@ class GpRepurposer(MetaModelRepurposer):
                  layers.
         :rtype: :class:`GPy.kern.RBF` or :class:`GPy.kern.Add`
         """
+        # GPy is imported here in order to avoid importing it during 'import xfer'
+        import GPy
         all_kernels = None
         for layer_name in feature_indices_per_layer:
             active_dims = feature_indices_per_layer[layer_name]  # feature indices corresponding to current layer
-            kernel = GPy.kern.RBF(input_dim=active_dims.size, name=layer_name, active_dims=active_dims.tolist())
+            kernel = GPy.kern.RBF(input_dim=active_dims.size, name=layer_name,
+                                  active_dims=active_dims.tolist())
             if all_kernels is None:
                 all_kernels = kernel
             else:
@@ -275,6 +279,8 @@ class GpRepurposer(MetaModelRepurposer):
 
     @staticmethod
     def _deserialize_target_gp_models(serialized_target_model):
+        # GPy is imported here in order to avoid importing it during 'import xfer'
+        import GPy
         # Deserialize the GP models trained per class and return
         deserialized_models = []
         for model_dict in serialized_target_model:

--- a/xfer/gp_repurposer.py
+++ b/xfer/gp_repurposer.py
@@ -137,8 +137,7 @@ class GpRepurposer(MetaModelRepurposer):
         all_kernels = None
         for layer_name in feature_indices_per_layer:
             active_dims = feature_indices_per_layer[layer_name]  # feature indices corresponding to current layer
-            kernel = GPy.kern.RBF(input_dim=active_dims.size, name=layer_name,
-                                  active_dims=active_dims.tolist())
+            kernel = GPy.kern.RBF(input_dim=active_dims.size, name=layer_name, active_dims=active_dims.tolist())
             if all_kernels is None:
                 all_kernels = kernel
             else:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We were setting the matplotlib backend because GPy is imported by `xfer.__init__()` and it imports matplotlib which will fail on OSX if the backend is not set. This is undesirable behaviour because we are silently overwriting the user's backend.

To get around this, we are importing GPy inside the functions where it is required to avoid importing it inside the `__init__`.  If a user wants to set their backend they can but it's not required unless the `GpRepurposer` is used.

In order for TravisCI builds to complete we added a command to create a matplotlib config file that sets the backend.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.