### PR TITLE
Set sudo required and trusty distribution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ os: linux
 python:
   - '3.4'
   - '3.5'
+sudo: required
+dist: trusty
 before_install: |
   if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
     brew update


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
For travis build, set sudo to required and specified Trusty Linux distribution. This forces Travis to use machines with 7.5GB RAM for Linux builds which reduced the run time from 16min to 10min. (https://docs.travis-ci.com/user/reference/overview/#For-a-finished-build) 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
