### PR TITLE
Perform codecov on develop branch

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,5 @@
 codecov:
-branch: master
+branch: develop
 
 coverage:
   precision: 2


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Switch codecov master->develop. The majority of PRs are submitted against develop so codecov should run on develop.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
