### PR TITLE
Add full stops to module docstrings

### DIFF
--- a/xfer/model_handler/consts.py
+++ b/xfer/model_handler/consts.py
@@ -12,7 +12,7 @@
 #   permissions and limitations under the License.
 # ==============================================================================
 """
-Model Handler constants
+Model Handler constants.
 """
 
 from enum import Enum

--- a/xfer/model_handler/exceptions.py
+++ b/xfer/model_handler/exceptions.py
@@ -12,7 +12,7 @@
 #   permissions and limitations under the License.
 # ==============================================================================
 """
-Exceptions for Model Handler
+Exceptions for Model Handler.
 """
 
 

--- a/xfer/model_handler/layer_factory.py
+++ b/xfer/model_handler/layer_factory.py
@@ -12,7 +12,7 @@
 #   permissions and limitations under the License.
 # ==============================================================================
 """
-Layer classes for adding new layers to models
+Layer classes for adding new layers to models.
 """
 
 import ast


### PR DESCRIPTION
*Description of changes:*
Full stops were missing from Model Handler's module docstrings so I have added them.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
