### PR TITLE
Move GPy to be with other imports

### DIFF
--- a/tests/unit/test_gp_repurposer.py
+++ b/tests/unit/test_gp_repurposer.py
@@ -14,12 +14,11 @@
 from unittest.mock import patch
 import numpy as np
 import os
+import GPy
 
 from xfer import load, GpRepurposer
 from .test_meta_model_repurposer import MetaModelRepurposerTestCase
 from ..repurposer_test_utils import RepurposerTestUtils
-
-import GPy  # Must be imported after xfer to avoid matplotlib backend errors because backend is set in xfer init
 
 
 class GpRepurposerTestCase(MetaModelRepurposerTestCase):


### PR DESCRIPTION
*Description of changes:*
GPy was moved to be after 'import xfer' because this is where the matplotlib backend was being set.  Since we are no longer setting the backend in the xfer.__init__ we can move GPy to be with the other imports and remove the comment.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
