### PR TITLE
Repurposer docstrings

### DIFF
--- a/xfer/meta_model_repurposer.py
+++ b/xfer/meta_model_repurposer.py
@@ -122,7 +122,7 @@ class MetaModelRepurposer(Repurposer):
 
     def predict_probability(self, test_iterator: mx.io.DataIter):
         """
-        Predict class probabilities on test data using the target_model (i.e. repurposed meta-model).
+        Predict class probabilities on test data using the target_model (repurposed meta-model).
 
         :param test_iterator: Test data iterator to return predictions for.
         :type test_iterator: mxnet.io.DataIter

--- a/xfer/meta_model_repurposer.py
+++ b/xfer/meta_model_repurposer.py
@@ -122,7 +122,7 @@ class MetaModelRepurposer(Repurposer):
 
     def predict_probability(self, test_iterator: mx.io.DataIter):
         """
-        Predict class probabilities on test data using the target_model i.e. repurposed meta-model.
+        Predict class probabilities on test data using the target_model (i.e. repurposed meta-model).
 
         :param test_iterator: Test data iterator to return predictions for.
         :type test_iterator: mxnet.io.DataIter

--- a/xfer/meta_model_repurposer.py
+++ b/xfer/meta_model_repurposer.py
@@ -141,7 +141,7 @@ class MetaModelRepurposer(Repurposer):
 
     def predict_label(self, test_iterator: mx.io.DataIter):
         """
-        Predict class labels on test data using the target_model i.e. repurposed meta-model.
+        Predict class labels on test data using the target_model (repurposed meta-model).
 
         :param test_iterator: Test data iterator to return predictions for.
         :type test_iterator: mxnet.io.DataIter

--- a/xfer/neural_network_repurposer.py
+++ b/xfer/neural_network_repurposer.py
@@ -116,7 +116,7 @@ class NeuralNetworkRepurposer(Repurposer):
 
     def predict_probability(self, test_iterator: mx.io.DataIter):
         """
-        Perform predictions on test data using the target_model i.e. repurposed neural network
+        Perform predictions on test data using the target_model (repurposed neural network).
 
         :param test_iterator: Test data iterator to return predictions for
         :type test_iterator: :class:`mxnet.io.DataIter`
@@ -137,7 +137,7 @@ class NeuralNetworkRepurposer(Repurposer):
 
     def predict_label(self, test_iterator: mx.io.DataIter):
         """
-        Perform predictions on test data using the target_model i.e. repurposed neural network
+        Perform predictions on test data using the target_model (repurposed neural network).
 
         :param test_iterator: Test data iterator to return predictions for
         :type test_iterator: mxnet.io.DataIter

--- a/xfer/neural_network_repurposer.py
+++ b/xfer/neural_network_repurposer.py
@@ -80,8 +80,8 @@ class NeuralNetworkRepurposer(Repurposer):
 
     def repurpose(self, train_iterator: mx.io.DataIter):
         """
-        Train a neural network by transferring layers/weights from source_model
-        Set self.target_model to the repurposed neural network
+        Train a neural network by transferring layers/weights from source_model.
+        Set self.target_model to the repurposed neural network.
 
         :param train_iterator: Training data iterator to use to extract features from source_model
         :type train_iterator: :class:`mxnet.io.DataIter`
@@ -173,7 +173,7 @@ class NeuralNetworkRepurposer(Repurposer):
 
     def serialize(self, file_prefix):
         """
-        Serialize repurposer to dictionary
+        Serialize repurposer to dictionary.
 
         :return: Dictionary describing repurposer
         :rtype: dict
@@ -190,7 +190,7 @@ class NeuralNetworkRepurposer(Repurposer):
 
     def deserialize(self, input_dict):
         """
-        Uses dictionary to set attributes of repurposer
+        Uses dictionary to set attributes of repurposer.
 
         :param dict input_dict: Dictionary containing values for attributes to be set to
         """


### PR DESCRIPTION
*Description of changes:*

* Added missing fullstops to docstrings
* Removed 'i.e.' because this was causing the docs to show a truncated version of the docstring.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
