### PR TITLE
Remove doc dependency

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,5 @@
 Sphinx==1.7.7
 nbsphinx==0.3.4
 sphinx-rtd-theme==0.4.1
-mock==1.0.1
 numpy==1.14.5
 scipy==0.16


### PR DESCRIPTION
*Description of changes:*
Remove dependency on mock library.

mock has been part of the standard library since 3.3 (https://docs.python.org/3/library/unittest.mock.html)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
