### PR TITLE
Add callbacks to NeuralNetwork Repurposers

### DIFF
--- a/xfer/neural_network_fine_tune_repurposer.py
+++ b/xfer/neural_network_fine_tune_repurposer.py
@@ -48,9 +48,10 @@ class NeuralNetworkFineTuneRepurposer(NeuralNetworkRepurposer):
     :param optimizer_params: Optimizer params required by MXNet to train target neural network.
            Default: {'learning_rate': 1e-3}
     :type optimizer_params: dict(str, float)
-    :param batch_end_callback: Each callback will be called with a BatchEndParam.
+    :param batch_end_callback: Called at the end of each batch. Each callback will be called with a BatchEndParam.
     :type batch_end_callback: function or list of functions
-    :param epoch_end_callback: Each callback will be called with the current epoch, symbol, arg_params and aux_params.
+    :param epoch_end_callback: Called at the end of each epoch. Each callback will be called with the current epoch,
+                               symbol, arg_params and aux_params.
     :type epoch_end_callback: function or list of functions
     """
     def __init__(self, source_model: mx.mod.Module, transfer_layer_name, target_class_count,

--- a/xfer/neural_network_fine_tune_repurposer.py
+++ b/xfer/neural_network_fine_tune_repurposer.py
@@ -48,12 +48,16 @@ class NeuralNetworkFineTuneRepurposer(NeuralNetworkRepurposer):
     :param optimizer_params: Optimizer params required by MXNet to train target neural network.
            Default: {'learning_rate': 1e-3}
     :type optimizer_params: dict(str, float)
+    :param batch_end_callback: Each callback will be called with a BatchEndParam.
+    :type batch_end_callback: function or list of functions
+    :param epoch_end_callback: Each callback will be called with the current epoch, symbol, arg_params and aux_params.
+    :type epoch_end_callback: function or list of functions
     """
     def __init__(self, source_model: mx.mod.Module, transfer_layer_name, target_class_count,
                  context_function=mx.context.cpu, num_devices=1, batch_size=64, num_epochs=5,
-                 optimizer='sgd', optimizer_params=None):
+                 optimizer='sgd', optimizer_params=None, batch_end_callback=None, epoch_end_callback=None):
         super().__init__(source_model, context_function, num_devices, batch_size, num_epochs,
-                         optimizer, optimizer_params)
+                         optimizer, optimizer_params, batch_end_callback, epoch_end_callback)
 
         self.transfer_layer_name = transfer_layer_name
         self.target_class_count = target_class_count

--- a/xfer/neural_network_random_freeze_repurposer.py
+++ b/xfer/neural_network_random_freeze_repurposer.py
@@ -48,9 +48,10 @@ class NeuralNetworkRandomFreezeRepurposer(NeuralNetworkRepurposer):
     :param optimizer_params: Optimizer params required by MXNet to train target neural network.
            Default: {'learning_rate': 1e-3}
     :type optimizer_params: dict(str, float)
-    :param batch_end_callback: Each callback will be called with a BatchEndParam.
+    :param batch_end_callback: Called at the end of each batch. Each callback will be called with a BatchEndParam.
     :type batch_end_callback: function or list of functions
-    :param epoch_end_callback: Each callback will be called with the current epoch, symbol, arg_params and aux_params.
+    :param epoch_end_callback: Called at the end of each epoch. Each callback will be called with the current epoch,
+                               symbol, arg_params and aux_params.
     :type epoch_end_callback: function or list of functions
     """
     def __init__(self, source_model: mx.mod.Module, target_class_count, fixed_layers, random_layers,

--- a/xfer/neural_network_random_freeze_repurposer.py
+++ b/xfer/neural_network_random_freeze_repurposer.py
@@ -48,12 +48,16 @@ class NeuralNetworkRandomFreezeRepurposer(NeuralNetworkRepurposer):
     :param optimizer_params: Optimizer params required by MXNet to train target neural network.
            Default: {'learning_rate': 1e-3}
     :type optimizer_params: dict(str, float)
+    :param batch_end_callback: Each callback will be called with a BatchEndParam.
+    :type batch_end_callback: function or list of functions
+    :param epoch_end_callback: Each callback will be called with the current epoch, symbol, arg_params and aux_params.
+    :type epoch_end_callback: function or list of functions
     """
     def __init__(self, source_model: mx.mod.Module, target_class_count, fixed_layers, random_layers,
                  num_layers_to_drop=2, context_function=mx.context.cpu, num_devices=1, batch_size=64, num_epochs=5,
-                 optimizer='sgd', optimizer_params=None):
+                 optimizer='sgd', optimizer_params=None, batch_end_callback=None, epoch_end_callback=None):
         super().__init__(source_model, context_function, num_devices, batch_size, num_epochs,
-                         optimizer, optimizer_params)
+                         optimizer, optimizer_params, batch_end_callback, epoch_end_callback)
 
         self.target_class_count = target_class_count
         self.fixed_layers = fixed_layers

--- a/xfer/neural_network_repurposer.py
+++ b/xfer/neural_network_repurposer.py
@@ -42,9 +42,10 @@ class NeuralNetworkRepurposer(Repurposer):
     :param optimizer_params: Optimizer params required by MXNet to train target neural network.
            Default: {'learning_rate': 1e-3}
     :type optimizer_params: dict(str, float)
-    :param batch_end_callback: Each callback will be called with a BatchEndParam.
+    :param batch_end_callback: Called at the end of each batch. Each callback will be called with a BatchEndParam.
     :type batch_end_callback: function or list of functions
-    :param epoch_end_callback: Each callback will be called with the current epoch, symbol, arg_params and aux_params.
+    :param epoch_end_callback: Called at the end of each epoch. Each callback will be called with the current epoch,
+                               symbol, arg_params and aux_params.
     :type epoch_end_callback: function or list of functions
     """
     def __init__(self, source_model: mx.mod.Module, context_function=mx.context.cpu, num_devices=1, batch_size=64,


### PR DESCRIPTION
*Description of changes:*
Added ability to pass custom callbacks to `Module.fit()` in `NeuralNetworkRepurposer`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
