### PR TITLE
Relax numpy version range

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ with open('docs/long_description.md', 'r') as fh:
 
 requires = [
     'mxnet>=1.2.0',
-    'numpy==1.14.5',
+    'numpy>=1.10.1',  # GPy import throws error for lower versions
     'scikit-learn==0.19.2',
     'matplotlib==2.2.2',
     'GPy==1.9.5'


### PR DESCRIPTION
Relaxing the scope of supported numpy versions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
