### PR TITLE
Bump major version

### DIFF
--- a/docs/demos/xfer-hpo.ipynb
+++ b/docs/demos/xfer-hpo.ipynb
@@ -19,7 +19,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      " /anaconda/envs/model_broker_env/lib/python3.5/site-packages/urllib3/contrib/pyopenssl.py:46: DeprecationWarning:OpenSSL.rand is deprecated - you should use os.urandom instead\n"
+      " /anaconda/envs/xfer_env/lib/python3.5/site-packages/urllib3/contrib/pyopenssl.py:46: DeprecationWarning:OpenSSL.rand is deprecated - you should use os.urandom instead\n"
      ]
     }
    ],
@@ -486,10 +486,10 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      " /anaconda/envs/model_broker_env/lib/python3.5/site-packages/paramz/parameterized.py:266: DeprecationWarning:Assigning the 'data' attribute is an inherently unsafe operation and will be removed in the future.\n",
-      " /anaconda/envs/model_broker_env/lib/python3.5/site-packages/paramz/parameterized.py:267: DeprecationWarning:Assigning the 'data' attribute is an inherently unsafe operation and will be removed in the future.\n",
-      " /anaconda/envs/model_broker_env/lib/python3.5/site-packages/paramz/core/parameter_core.py:290: DeprecationWarning:Assigning the 'data' attribute is an inherently unsafe operation and will be removed in the future.\n",
-      " /anaconda/envs/model_broker_env/lib/python3.5/site-packages/paramz/core/parameter_core.py:291: DeprecationWarning:Assigning the 'data' attribute is an inherently unsafe operation and will be removed in the future.\n"
+      " /anaconda/envs/xfer_env/lib/python3.5/site-packages/paramz/parameterized.py:266: DeprecationWarning:Assigning the 'data' attribute is an inherently unsafe operation and will be removed in the future.\n",
+      " /anaconda/envs/xfer_env/lib/python3.5/site-packages/paramz/parameterized.py:267: DeprecationWarning:Assigning the 'data' attribute is an inherently unsafe operation and will be removed in the future.\n",
+      " /anaconda/envs/xfer_env/lib/python3.5/site-packages/paramz/core/parameter_core.py:290: DeprecationWarning:Assigning the 'data' attribute is an inherently unsafe operation and will be removed in the future.\n",
+      " /anaconda/envs/xfer_env/lib/python3.5/site-packages/paramz/core/parameter_core.py:291: DeprecationWarning:Assigning the 'data' attribute is an inherently unsafe operation and will be removed in the future.\n"
      ]
     },
     {

--- a/docs/demos/xfer-modelhandler.ipynb
+++ b/docs/demos/xfer-modelhandler.ipynb
@@ -1123,7 +1123,7 @@
      "output_type": "stream",
      "text": [
       "WARNING:root:Already bound, ignoring bind()\n",
-      "/anaconda/envs/model_broker_env/lib/python3.5/site-packages/mxnet/module/base_module.py:488: UserWarning: Parameters already initialized and force_init=False. init_params call ignored.\n",
+      "/anaconda/envs/xfer_env/lib/python3.5/site-packages/mxnet/module/base_module.py:488: UserWarning: Parameters already initialized and force_init=False. init_params call ignored.\n",
       "  allow_missing=allow_missing, force_init=force_init)\n",
       "INFO:root:Epoch[0] Train-accuracy=0.100000\n",
       "INFO:root:Epoch[0] Time cost=58.709\n",

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.5
+current_version = 0.3.6
 tag = True
 commit = True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.6
+current_version = 1.0.0
 tag = True
 commit = True
 

--- a/xfer/__version__.py
+++ b/xfer/__version__.py
@@ -11,4 +11,4 @@
 #   express or implied. See the License for the specific language governing
 #   permissions and limitations under the License.
 # ==============================================================================
-__version__ = '0.3.6'
+__version__ = '1.0.0'

--- a/xfer/__version__.py
+++ b/xfer/__version__.py
@@ -11,4 +11,4 @@
 #   express or implied. See the License for the specific language governing
 #   permissions and limitations under the License.
 # ==============================================================================
-__version__ = '0.3.5'
+__version__ = '0.3.6'


### PR DESCRIPTION
Bumping version to 1.0.0 and removed hpo notebook from travis build (tracking gpyopt error in PR #42 )


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
