### PR TITLE
Update travis build machines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ before_install: |
     # Confirm versions
     python --version
     pip -V
+    pip install --upgrade pip
     if [ $PYTHON == 3.4.4 ]; then
       # GPy requires numpy during setup for Python versions less than 3.5
       pip install numpy

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,6 @@ before_install: |
     fi
   fi
 install:
-  - pip install --upgrade pip
   - pip install -r requirements.txt
   - pip install -r test_requirements.txt
   # work around issues with GPy and GPyOpt setting matplotlib backend

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - '3.4'
   - '3.5'
 sudo: required
-dist: trusty
+dist: xenial
 before_install: |
   if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
     # Get latest version of brew
@@ -58,7 +58,6 @@ jobs:
       python: '3.6'
       if: branch != master
     - stage: notebooks
-      os: osx
       language: generic
       python: '3.6'
       env: PYTHON=3.6.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,9 +60,8 @@ jobs:
     - stage: notebooks
       language: generic
       python: '3.6'
-      env: PYTHON=3.6.6
       script:
-        - brew install graphviz
+        - sudo apt-get install graphviz
         - pip install -r docs/demos/requirements.txt
         - travis_wait 40 pytest --durations=0 --notebook
     - stage: release

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,6 @@ jobs:
       python: '3.6'
       if: branch != master
     - stage: notebooks
-      language: generic
       python: '3.6'
       script:
         - sudo apt-get install graphviz


### PR DESCRIPTION
*Description of changes:*

* Update version of linux build machine.
* Switch notebook tests from osx to linux because linux machines now have 7.5GB RAM to osx's 4GB (https://docs.travis-ci.com/user/reference/overview/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
