### PR TITLE
Replaced gpyopt with emukit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_install: |
 install:
   - pip install -r requirements.txt
   - pip install -r test_requirements.txt
-  # work around issues with GPy and GPyOpt setting matplotlib backend
+  # work around issues with GPy setting matplotlib backend
   - "echo 'backend: Agg' > matplotlibrc"
   - pip freeze
 script:

--- a/docs/demos/requirements.txt
+++ b/docs/demos/requirements.txt
@@ -1,4 +1,4 @@
 ipython==6.5.0
 nbconvert==5.3.1
 jupyter>=1.0.0
-gpyopt>=1.2.5
+emukit>=0.4.5

--- a/docs/demos/xfer-hpo.ipynb
+++ b/docs/demos/xfer-hpo.ipynb
@@ -5,17 +5,15 @@
    "metadata": {},
    "source": [
     "## Xfer with HyperParameter Optimization\n",
-    "When training neural networks, hyperparameters may have to be tuned to improve accuracy metrics. The purpose of this notebook is to demonstrate how to do *HyperParameter Optimization* (HPO) when repurposing neural networks in [Xfer](https://github.com/amzn/xfer). Here, we use [GPyOpt](https://github.com/SheffieldML/GPyOpt) to do HPO through Bayesian Optimization.\n",
+    "When training neural networks, hyperparameters may have to be tuned to improve accuracy metrics. The purpose of this notebook is to demonstrate how to do *HyperParameter Optimization* (HPO) when repurposing neural networks in [Xfer](https://github.com/amzn/xfer). Here, we use [emukit](https://amzn.github.io/emukit) to do HPO through Bayesian Optimization.\n",
     "\n",
-    "Note that depending on number of epochs, the target data set and transferability between source and target tasks, the default hyperparameter settings in Xfer could give desired results and HPO may not be required. If someone wants to try HPO, this notebook shows how to do it using GPyOpt."
+    "Note that depending on number of epochs, the target data set and transferability between source and target tasks, the default hyperparameter settings in Xfer could give desired results and HPO may not be required. If someone wants to try HPO, this notebook shows how to do it using emukit."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import warnings\n",
@@ -30,7 +28,7 @@
     "import random\n",
     "import time\n",
     "\n",
-    "import GPyOpt\n",
+    "import emukit\n",
     "import mxnet as mx\n",
     "import numpy as np\n",
     "from sklearn.model_selection import StratifiedShuffleSplit\n",
@@ -50,9 +48,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def set_random_seeds():\n",
@@ -60,8 +56,6 @@
     "    np.random.seed(seed)\n",
     "    mx.random.seed(seed)\n",
     "    random.seed(seed)\n",
-    "    GPyOpt.util.general.np.random.seed(seed) \n",
-    "    GPyOpt.optimization.acquisition_optimizer.np.random.seed(seed)\n",
     "    \n",
     "def get_iterators(data_dir, train_size=0.3, validation_size=0.3, test_size=0.4, batch_size=1, \n",
     "                  label_name='softmax_label', data_name='data', random_state=1):\n",
@@ -194,9 +188,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Download source model\n",
@@ -269,12 +261,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Trained neural network with default hyperparameters. Precision: 0.6875\n"
+      "Trained neural network with default hyperparameters. Precision: 0.25\n"
      ]
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA1oAAABNCAYAAAC/mRUgAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvOIA7rQAAHqdJREFUeJzt3X10FNXdB/DvLwkEgoC8VCFAABUeEC1WRGwVfKBqihUfpFqDlUblqEXaaguF41Nrq6UKBVQqqFVADmrh4FMRFYlFsVK1HCG+UNTUWEhIkZckIjYkQCD3+WMz6+xkZndmd3bnZb+fc/acZHde7m/m3jtz596ZEaUUiIiIiIiIyD05XieAiIiIiIgobNjQIiIiIiIichkbWkRERERERC5jQ4uIiIiIiMhlbGgRERERERG5jA0tIiIiIiIil7nW0BKRG0TkTbeWR5StWJaIKB7WEeQF5jsi59ijRUQZJyJVInKJ1+mg7MO8539h3EdhjInIK0EqT2xoeURE8rxOg9vCFlPY4gkKbvdwboMgxBSENGa7MO6jMMZE4dyvQYjJb2lMqqElIv1E5DkRqRWRehFZrPttgYgcFJFdIjJe931XEVkmIntFZI+IzBGRXN3vN4nIx63zviIi/Vu/FxF5UEQOiMiXIvIPETmr9bf81vXtFpH9IvKYiHRMfnOktg1E5HQR2dT6f52IPCMiJ+vmqRKR2SKyHcBhv2WGsMUUhHiysSyJyFMAigC8KCINIjJLRJSITBWR3QA2tU53gYi8LSJfiMgHIvLfdreB14KQ95wKQ0xBzHvZVkcEcR8lEsSYsi3f2d0GErA6zygMMQWuPCmlHH0A5AL4AMCDADoB6ADgIgA3AGgGcHPrNNMAfAZAWudbC+CPrfOcAuAdALe2/vY/AD4FMBRAHoC7ALzd+lsxgHIAJwOQ1ml6t/72IIAXAHQH0BnAiwDudxqTi9vgDACXAsgH8DUAmwE8pJuvCsD7APoB6JjudGZzTEGIJ5vLUut2vqT17wEAFICVrTF1BNAHQD2AyxG5IHRp6/9fS7QNvP4EIe9lc0xByntxtvsNCHEdEaR9FMaYsjXf2dwGgavzwhhToMpTEsF9E0AtgDzD9zcA+FT3f0Fr4L0AnArgqH4HAZgM4PXWvzcAmKr7LQdAI4D+AMYB+ATABQBydNMIgMMATjekbVcGdrDpNjCZbiKA9wwZ4yavM2g2xBSEeLK5LMG8kjxN9/tsAE8Z5nkFQGmibeD1Jwh5L5tjClLey9Y6Ikj7KIwxZWu+s7MNTKbzfZ0XxpiCVJ6S6f7rB6BaKXXc5Ld92h9KqUYRAYCTELkS0Q7A3tbvgEghq2n9uz+ARSKyULcsAdBHKbWptct6CYD+IvIcgJmItMQLAJTrlimItNjTzXQbiMipABYBGI3IlZccAAcN89bAn8IWUxDiYVmKpd/u/QFcIyITdN+1A/B662/xtoHXgpD3nApjTHp+zXusI77i132UCr/GxHwXzjovjDHp+bI8JXOPVg2AIodjNGsQaT32VEqd3PrpopQapvv9Vt1vJyulOiql3gYApdQflFIjAJwJYDCAXwCoA9AEYJhunq5KqZOSiMkpq21wHyKt6rOVUl0AXI9IpaCnMpC+ZIQtpiDEk81lyWwb67+rQeRqlD6OTkqpuUi8DbwWhLznVJhiClLey9Y6Ikj7yK4gxZSt+c4YT1jqPE2YYgpMeUqmofUOgL0A5opIJxHpICIXxptBKbUXwF8ALBSRLiKS03rz3cWtkzwG4E4RGQZEb1K7pvXvkSIySkTaIdKFfARAi1KqBcATAB4UkVNap+0jIsVJxOSU1TboDKABwCER6YNIRREUYYspCPFkc1naD+C0OL8/DWCCiBSLSG7rtvlvEelrYxt4LQh5z6kwxRSkvJetdUSQ9pFdQYopW/OdXpjqPE2YYgpMeXLc0FJKnQAwAZGb53YD+DeAa23M+kMA7QF8hEiX5P8B6N26zLUA5gFYLSJfAtgBQHuSTRdECtpBANWI3Mw2v/W32YjcXLmldb5XAfyX05icirMN7gFwLoBDANYDeC7daXFL2GIKQjxZXpbuB3CXiHwB4Grjj0qpGkRunv5fRMaU1yBS+Wt1luU28FoQ8p5TIYspMHkvi+uIwOwjBwITUxbnu6iQ1XkAQhdTYMqT9qQYIiIiIiIicglfWExEREREROQyNrSIiIiIiIhcxoYWERERERGRy9jQIiIiIiIicpmjFxb37NlTDRgwIE1JcV9VVRXq6uqM7wKIEbaYwhYPwJj8gDEFgxcxlZeXY8SIEa4tzygb91PQ4gGA8vLyOqXU16x+D1pM2ZjvAMbkB4wpGOzEBDhsaA0YMADbtm1LPlUZdt555yWcJmwxhS0egDH5AWMKhkzHJBI5xpSXl0e/c/tJtl7sJxFxPQ69sNXjACAi1fF+D1pMrB+CgTEFQ7bGBHDoIBERpUApFf0AXzW+gkpLf9DjICIi72WkoSUiafsQEfmdUgpDhw6N1lvXXXed10lKmVmvj9bgCmr9rKVZ32gMYhxEROQPaW9oaQdjtz+bN29Oa5rZqIuV7fETOaWvO3JycvDss89G66+LLroo+n0QJRpap29wBY0Wl/54w+MAERElI61Hef3B2M0DlYhgzJgxKS8nHmPDLltp+yybt4FfTZs2jb29Hlu0aJHl9j98+HBMHXLWWWdF57vtttuglEL79u0Dt6+cpDdIvVvx0mgcGmk2bRBiJCKizEpLQ+tf//pXSifn+pOVV155Jfr9ww8/HHMCky5WV2Kz8SQ2qENozj//fMsT4Pnz5ztalh9if/fdd9vEMXjwYMse38bGxuh0VVVVnqY9UzLV4NRv28rKSst9UFBQkHBZR44cQUtLi+f5yy7j0Do7glCH2I3LqpfLr3EREZG3HD110I533nkHo0aNMh27n4zi4mIAyR3gU6VvLBrX60V6vBK0m9wT7RsRwXvvvYc//elPtpaljz/T+1uLJS8vz9G6O3bsaLrfwppf4+1zN8vqLbfcgieeeMLV7SgiqKur83XPcap5yKyx5ZdYk02Pfvqg1I1EyfrVr36FOXPmAADatWuHlStXoqSkxONUEfmf6z1a+kZWRUVF3KFNOTk5mDFjRptlmD3F6qabbopeRVy7dq3byY5hduA1Hkj9cpKQKUE5kdi0aROA+PtHKYVVq1bhjjvuiLssEcGkSZOi/3fq1AlFRUXuJNSGgoIC9OzZE0opNDc3J70crSxpJ/NB2Zd2JTpRdvNCgduNLE2PHj1cX2Y6pBq73xonbjf6/BBTPI2NjWhqavI6GRRAWiNLKYX6+nqUlZXFPb8rKCjAgQMHPE41kfdcbWhNmTIFwFdXLceOHYujR49aDq05cuQITj/9dMuC2r17d/zjH/8AACxbtgz19fUAEHPymy7Z1pCyor9HKwjb5Nvf/ratdCqlovfXmNG+//Of/xz9rqGhATU1Ne4kNIE1a9agqakJtbW1ri2zR48eUEqhW7duvj8htMvqokg6Loxce+21eOSRR1JeThCZ3Wub7Mc4/M5rqeaNoNSPkyZNQpcuXdC1a1fLfZOp+s2pTA0Lpvi0Mtu5c2esWLEi7gPLPv30U/Tu3RsigpNOOsnrpBN5xtWG1tNPPx1T0Pbu3Yv27dtbTt++ffvoTeFmnx07duCCCy6Imad79+5uJrkNPw/f8UpQtseXX37paHqrey1EBLfccotp3IsWLcIPfvADt5JsqbKyMm3L/vzzz9O2bC+YDVO2GuqbijVr1mDatGkpL8fK9u3bfX/yGO/Eyu7HL/y+rd125MgRvPHGGzh27JjlvikqKsLEiRO9TmqUWePcONqFDa/MsnuBpLCwECdOnIBSCsePH+f+oazl62cLFxYW4vDhw9H/RQSff/45brzxxrSu16ziTseJm18kOkgFJdauXbsmff+I8fPHP/7RdNqf/vSntu7tStUvf/lLAMCgQYMczxv2kw6rEyvtf7PY/XSCb+Xss8+OPhjD+Jk3b57XyQsl/YWWZJhdmPNr2aurq0PXrl3jTqOUwrp16zKUInviDQm2anhRet13330Jt7N+Xxw5cgQnTpyAiOCSSy7JRBJddc8999jqrZ8wYQIef/xxPPXUU5g3bx4mT56MRx991Ovkk8d83dAy0nqzli9fnrZ16Ct1q3s73B7X76VEPXh+uwrttblz52L69OkZWZc2/MIJEcH111+P5uZmywPh6tWr3Uiep8yGn2n5NMj51erqfU1NTfRg/vWvf93rZIaKWc+2HVYN+lQbb+mydevWmFcMAJEYzjvvvJjv/DKk0ykeqzLnzjvvjL6awiyv79mzB/379wcQeUAaAOTk5EAphddeey1w+es3v/mNrd76n/3sZ9i1axe2bdsGACgtLcXcuXNx++23exyBNWNjcevWrV4nKXRcf+qg3okTJ5CXF7uKVCvCTFWkZo2seD1cQWRsZGn/hy1ON915550Z3Sba/tDW+eGHH0ZPlozpeOGFFwAATz31VNxlTp48OVT71SyWsA0BXrx4MRYvXgwAGDt2bOji8wNjr4id7Ruvt8XvJ5Nm9b3GWO94hccj/3j88ccxffp0LFmyBABw9OjRmN9FBOXl5Tj33HPRp08fVFdXm+YjpSL354sIduzYgWHDhmU0jnQaN24cxo0bF/NddXU1RASLFi3yKFXmtHJVX18fc0vO0KFDUVFREf2/tLQUK1asyHTyQiWtPVraI6m1zzPPPOPqwWfKlCnRIVZu0Q8/MmtkheWqmXE/GBuWxt6CbGO8eR+IPNLWC7169Yq+k6m0tBQfffSR6XRXXnklAGD27Nk4duyY6TR9+/bFZZddlp6Eesg4bDAdZfSqq67CSy+95PpynXr99ddx+PDhrC2b6WY1kkHPTiMk6MeJvLw89O7d27P1m92f5XReP/YsxmM2HM0vbr755jYPA9KnUSmFESNGYP/+/QAiF4dEBI2NjW2W1aFDBygVeYm7n2LMBto+q6mpgVKqzXMPPv7445gypz09PGz3dmeS6w2tlpYWy99WrFiBnBz3Vrly5Urcd999ri0PMB/37ccbud1gjCeMMTrVt2/f6D0xSimUlJQgJycn5oCfaXv37kVTUxNaWlpQXl6OM88803JapRR+//vfIz8/3zSte/bsiXkJeFAZT0biDRt00kMRz5o1azBhwoSUluEWOy9DDgq/nGiZndymerLrl9isxCsXzc3N2LdvX4ZTlPq71qzu3QoKY/r91uDSaCffxuHbvXr1AgBMnz4dSil07NjRchlKKTzyyCO+jE+zbds2jBo1yutkpEzLR0eOHIFSCn379rU135YtW6CUQo8ePXy9n/zM1YbWNddcg7/85S/R/7dt2wYRwQMPPICXX34ZGzduxIkTJ0znPXr0KN58803LHblgwQI3k5rV7BSWbCxQIoI9e/ZAKYVZs2YBAFatWhU9WB8/ftyztCmlkJubiwsuuCBhg8/qdxHxRY+MG+w2et3s4TIOg9azeohFonKUyhXstWvXxn2qaxD47cKO2QU2wLphb+TX3ohDhw61ySt2ylCme07t9mA5SZPf8pgVq3zl1wbXrFmzcM455wAAqqqqkJ+fD8D5sNlp06ZF51m5cmVa0pqKO+64A3/4wx9SWkb37t3xwQcfuJQi+7SnPYoImpuboZSK7ien/JoPg8DVhtbFF1+Mt956K/r/iBEjoJTCZ599hgceeCDuwalDhw64//77LZf9i1/8ws2kZj0nJ6nZ5MUXXzT9/t1338VFF12U4dTEUkphy5YtKS3ju9/9rkup8Y5ZT6ye8UQ33SdaIoLc3FzLG6StypF20clsejsHw4kTJ6b0Imuyx6qHxKqR7McRED//+c/x5JNPOp4vkz2nVsP2zfhp27rBzrHWmPe8Nm/ePOzevRsiggEDBsTcs6XVY06GmymlUFpaitGjR6cjuUl76623cP7556e0jPr6+mijNN30jat27dpF66J4Fwqd0B+n3Fpm2Lna0Bo+fDjKy8vbfL9gwQK8+uqrpvOICN5//30opbB+/XrH6ywtLcWzzz7reL5sZXcIVdgOZIloB64rrrjC9Pfa2tq4QyAy5eDBg0kdZLUhA2GUyZNdY8Pp3//+d/R7p7R7WM3WYXWPHaWH3TJl7HEx+/jR8uXLcd1113mdjLjStQ390Cixw+5x2U5jP1Pi7TNtuNmpp57qaHnxRjYFXWlpaZsXhrtN37hKZ30UxGG5XnG1oXXGGWc47h5VSuGcc85Bjx49knoZ8eTJk9nQsslJgQha4XHjRbLxHsFaXFyMjRs3pryOVJ188skYNGhQUvsn2SEDfmY8oCTqRXJrnSKC4cOHo1+/fp6dXM+dO9eT9YaZX3oLKHskc/9oUBr5SikcOHDA8VDPCy+8MPrAhkyoq6tDeXm55YOm3KCUwoQJE/DJJ5/YGvGQDDfuRXbi+PHjWLFiBevMBFzt9+vcuTPq6+sdz6dU5D0xubm5KCwsdDTv4MGDsX37dsfrzFbJ9GZluvA65dYQsYceesj0+6KiopSW67ZPPvkEIoKKigoMGTIEADBp0iSsXbs2Zjr9FSc/778gUkpFXyb92WefOa63rFRWVmLw4MGYM2cOli5dajrNzTffHJMOSp1ZnUcRgwYNQnV1dfS9SEHj53rQaT7L1HBoNymlcPvttzva/m+++SaA9Md71VVX4fnnn0f37t1x1llnobGxMfoOLI2b67766qtdW5ZRMufebigtLcUNN9zgybqDwjcDLPv165fUfHl5eWl9SEGQKrR4/HiQSdWxY8eQn5+PTZs2YezYsSkvb/Hixfjxj38c893QoUOjj0H1E+1KmJautWvXRv8eN24c/vOf/wAAZs6c6Vkaw66yshJPPvkk+vTpk3BaqxMq4/dnn302gMjDCw4dOmQ6jxf3q2Zbw8Nv5Z3CK96961bTBu14vmjRIlx//fWO062Uwt///ve0xfv8888HajvG07Nnz4SxNDY2olOnTjHf9erVC3v37k1p3cbzEYrlm4YWpY8bJ0l+K0RlZWUYP3589GlvqdCedvTDH/4QP/nJT2IaLxUVFb6KW6+4uBg5OTloaWlBYWEhRASXX345Xn/99WiaFy5c6Nv0h8GNN96Im266CYD5CVNNTQ2KiopMfxMRrF69OvqYXW24TENDQ5uDIaVHEHsInBIR7Ny50+tkpCTR8cdvxyc74h23wnhhY+TIkaitrXW8r775zW9CRDB16lQsW7YsjSm0tmfPHlsX1LwiIhgzZkzcaYqKikyHYu7btw8DBgxAVVVVwvXU1taiuLg4+lyFffv2Re/BKygogIi4ck6WLvp0ZbK+cPUerU6dOrV5W3i67du3z3dDu/wq2czvt/HfIoLx48enPL5Z/6jmKVOmxIyZFhGUlJT4Km6jsrKyaPq0x9JfeeWVMVc9y8rKvExiVlBKYenSpab391g1srT51q9fjzlz5mDOnDkQEfztb3/zZSPLz+UgWWYPFgirgQMHRv/WYh08eLCteSsrK/HFF1+kK2mWnD4wIFHDxU952KqBb/VAH+Mx2OzYl4n8W1xcjL/+9a9t0mv36YI9e/ZEY2OjZVq1J+atW7cu5vuWlhYsX74cTU1NSac9GVp83/rWt6J/OykLdh5UsnnzZkcPDDFbBwC88cYbltM0NjZGR+boP1OnTgUAVFdXJ1yHiOCUU07Be++9F82L2jvTgMirIJRS0feO+o2xXGWyznf9hcVG2ru03AyqrKwsury6urqUMmk20D8owOpJRXY/XsvNzQVg//H0xo/+0acNDQ2WT0tSSmX8okEympubY/bLrbfeCuCrx7gXFxd7kq5sM3Xq1JiToXvvvdfWyd3KlSuxYcMGlJWVYebMmZ6/QsCKH8p+uhhvTA9zrCKCzp07QymFysrKhNNqeXj48OEZSmGEk4c86MtZkPZdvAswyTYK092YfPTRRzF58mQAQElJCc444wwo5exlth07dsTRo0dNp9eemDdx4sQ2vymlUFBQkLEnsmr5SimF6urq6N/dunVzPL9SCl26dDGNefTo0Thw4EBSabz00kvRqVOnhPvdapqlS5fafoWD3YevKKXwwgsv+KIuNZ67Gi9WuP0wEitpHzo4cuRI1ytBN3ozslWyFbFftnVLS4vtRhbwVbwNDQ3o3LlztCIPC6v3WLz88suhijMotHx38cUXO74Xwc+ypb41Hquc7he/9ZyYWbZsGdq1a2f5ux+HUxrvAbHqzTHmU9474q6BAwdi3759AIDVq1cnfTLdvn376BAzp/VkJoanxUuXnTwlIvj4449jvjt06BCGDBnian608yTk+fPnx/1deym5fnv27t0bu3btQn5+Pn73u9/Fnf+xxx7Dj370o5jvJkyYAKUU+vbt60n5czJEMBN1RNp7tIBI0Hv27HFlWXV1ddFlAsDll1+OZ555xpVlZ5N4vVR+68XS2C0Mu3fvbvPdSSedFNqDrfHkIptPLLzOs9pVMv3wGgqeVC4O+qnuvOSSS9o8jfT73/8+1q1bZzlszW9DxTVWPY5mw+oyebU63ezE4FWcTnse9ftPy2v6tO/cuRMiEr3v1WqdOTnpO3UtKCjA3XffnfJytCcC61VUVFj2bCVD256jR4/Gc889ZzrNrFmzbJVn/X7cvHkzOnToABHBXXfdFXe+adOmWY6Aevjhh9Nal1it126e1KS7rkh7j5ZSCrt27cKFF16IlpaWlJenf7KKiCAnJyethS5szK72WTG7OhgE2mOIjem9++67MWzYMC+SlDEiglGjRnmdDE8EJX9SMOiPM8n0TvrhJP+1117Dq6++Gv3fLA4/9mBZcdrj6OeYjPnKKr/YacDYmc4PlFKYNWsWhgwZgoqKiuh32rYYOHCg7UZBui4oNjU14Z577kl6/kTpOnToUMy+PnjwYNLr0tazdetWLFmyBN/73veSXpaeNiRUk+g80Qtu7n9j499tGWmhDBw4EFVVVa4eeLRlnThxwrVlZptE+8MPJwpu+u1vf4sdO3Z4nYy00A48Y8eOxZYtW7xODpEjfq5rnF7tdHIxy0vjx4+HiKC2tjYQJ+lGQUyzxtjjlupQVb9vi5deein69/z586ONLE0y5eSVV17xbdmyS0TQo0ePlPffyJEjsWLFCtP7qPbv3w8RabPNgci5ebKNi2uvvRYLFixIKd3JsnuRwsmyAj900A2rVq0CAMyePRsign/+85++r1z8LshXAxMxpv2xxx7zKCWZo5TCpk2bvE4GkSNBqGecnAj6uXEFRC5Oigg2btwIpRR69uzpdZIIaHPiaPbR/2acx8+uuOIKAJG0v/3226bTOC03l112WcrpWrVqVdxtbGc/pDJ/MnE7dcopp0AphaFDh7ZJx9ixY5POQ2vWrMGMGTNcTm1ibvdkZaIMBeY9WiUlJYGrXPzKbsH288mCFbM0M98QUaqcnhD5sb5hXehPVnnL6qp9EPdfojRrDX8nJ7+pNlJKSkpQUlIS812i9b///vv4xje+YTlNovkzdXJvlMo6zbbzbbfdlmqSHLPadskMJc3kfkhLj1ai1ryIYP/+/Y6XGYQu8iBINB7VyQ2uftTQ0BCT1xoaGrxOEhGFULwr1frvvHDvvfdi4cKFMWkJap0eZvrGr537sfyw/5qbm11f5syZM233COk/I0aMcD0tI0eOtPwtXiMrkUw9mj4djOeFS5Ysyej67eR9ux0ImS5Hrje0zMaIGj/Hjx9HYWGh7YK0c+dOX1QuYWDWiDKeKATNhg0bYgqP9s4I7WPnPRNElDonJ0hBrXf06bZzvPOq7nnnnXcwY8YMNrB8zOpCp5PpM00phfbt20NEUFhYmPRyPvzww5iytH379ph1eFW2lFIx738dOHAgfv3rX6Nbt24QEVu3IUyaNMn0+/z8fF/sw6Cx0zCye6FCmzaTPBk6mJuby4dY+Iy+0eXXisBqmMBpp53m2zQThYmdRlGYy2JQYpsxYwbWr1+PDRs24Dvf+Y7XyaEEgnaxQSsHmzdvTjrtRUVFaG5utnwXpJe0+LSHPXTs2BE7duxAnz59bM2rv4A0bNgw7NixAyKCpqam9CU6hNxqGHk9ZNp/OZwyys8NKzNBSitRmLDsBcfChQujwwbJ38zKVVAaXmPGjAl1vTBz5syk5tNvk+PHj0NEcODAAXTo0MGtpGWNTDWy0lnm2NCiqKBU7kRERER+l5eXF+rGaLolc16qH/1kZ9unu8OBDS0C4H3XKhEREbXFi6CUjZK5pcXpwy4yMaorMO/RovRiA4uIiMifeIwmssdPjSyAPVpZxeqqmP57XjkjIqIgCPvxKuzxEXkh0yO42NDKErwaRkREYRHm4e5hjInID7yoN9jQIiIiosBgQ4SInND3DmfFe7SIiIiIiIjSxcsGloYNLSIiIiIiCh2ve8D51EEiIiIiIvIdJw0l47ReN7IAQJwkQkRqAVSnLzmu66+U+lq8CcIWU9jiARiTTzCmYGBMwRC2ehwIX0xZl+8AxuQTjCkYEsYEOGxoERERERERUWIcOkhEREREROQyNrSIiIiIiIhcxoYWERERERGRy9jQIiIiIiIichkbWkRERERERC5jQ4uIiIiIiMhlbGgRERERERG5jA0tIiIiIiIil7GhRURERERE5LL/B02gOb1mqJRgAAAAAElFTkSuQmCC\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA1oAAABNCAYAAAC/mRUgAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4xLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvDW2N/gAAG7xJREFUeJzt3X1wFdX5B/DvScJbECmQKgSMoMJA0WKLiK2ChaIpVvwhrTVYaaqMWqSttlAcp62tSi0UcEoF3wrIgBYGp0WsSBSFStUyQnyhsaamhUSMBJKotCEB8nJ+f4Td7t3s3rt7776c3fv9zNyZ5N69u+e5+3aePWfPCikliIiIiIiIyDs5YReAiIiIiIgobphoEREREREReYyJFhERERERkceYaBEREREREXmMiRYREREREZHHmGgRERERERF5jIkWERERERGRx3xLtIQQ1UKIKX7NPwyMSX1xiwdgTFHBmKKBMakvbvEAjCkqGFM0RCmmUFq0hBB5YSzXT4xJfXGLB2BMUcGYooExqS9u8QCMKSoYUzQoF5OU0vMXgPUAOgC0AGgCsACABDAbwAcAdp2a7hIArwP4FMA7AL5imEdfAKsBHAJQC2AhgFw/ysuY4hFT3OJhTIyJMTGmbIspbvEwJsbEmLI7Jj9/iGoAU079PfTUj7AOQG8AvQAMBtAI4Cp0tqxdcer/z576zmYAj52a/gwAbwC4LawVy5iiEVPc4mFMjIkxMaZsiylu8TAmxsSYsjemoH+Ecwyf3wVgvek7LwAoBXAmgBMAehk+mwlgp4IrljEpFFPc4mFMjIkxMaZsiylu8TAmxsSYsjemoPsxHjT8fTaA64QQ0wzvdQOw89Rn3QAcEkJon+WYvq8KxqR+THGLB2BMjCk8jIkxhSFu8QCMiTGFhzEFFJOfiZZM8d5BdGabt5gnEkIMQme2WSClbPOpfOlgTAaKxhS3eADGlIAxBYoxGTCmwMQtHoAxJWBMgWJMBkHH5Oeog4cBnJPk8ycBTBNCFAshcoUQPYUQXxFCDJFSHgLwIoBlQojThRA5QohzhRCX+1heJxiT+jHFLR6AMTGm8DAmxhSGuMUDMCbGFB7GFGZMPvaf/D90jv7xKYD56Mw080zTjAfwCoCPAdQD2Aqg6NRnfQE8AuBDAEcBvAWgxO9+n4wp2jHFLR7GxJgYE2PKtpjiFg9jYkyMKXtjEqcWSERERERERB4J5YHFREREREREccZEi4iIiIiIyGNMtIiIiIiIiDzGRIuIiIiIiMhjrp6jVVBQIIcOHepTUbxXXV2NhoYGkWyauMUUt3gAxqQCxhQNYcRUXl6OsWPHejY/s2xcT1GLBwDKy8sbpJSftfs8ajFl43YHMCYVMKZocBIT4DLRGjp0KPbu3Zt+qQJ20UUXpZwmbjHFLR6AMamAMUVD0DEJ0XmOKS8v19/zeiTbMNaTEMLzOIzidhwHACFETbLPoxYTjw/RwJiiIVtjAth1kIiIMmB6bomefEWVVv6ox0FEROELJNESQvj2IiJSnZQSo0aN0o9bN9xwQ9hFyphVq4/+gMaIHp+1MhuTxijGQUREavA90dJOxl6/du3a5WuZmdQlyvb4idwyHjtycnLw9NNP68evyy67TH8/ilJ1rTMmXFGjxWU83/A8QERE6fD1LG88GXt5ohJCYOLEiRnPJxlzYpettHWWzb+BqubMmcPW3pAtX77c9vc/duxYwjHk/PPP1793++23Q0qJ7t27R25duSlvlFq3kpXR3DXSatooxEhERMHyJdH697//nVHl3FhZeeGFF/T3H3rooYQKjF/srsRmYyU2ql1oLr74YtsK8JIlS1zNS4XY33zzzS5xjBgxwrbFt7m5WZ+uuro61LIHJaiE0/jbVlVV2a6D/Pz8lPM6fvw4Ojo6Qt++nDJ3rXMiCscQp3HZtXKpGhcREYXL1aiDTrzxxhsYP368Zd/9dBQXFwNI7wSfKWOyaF5uGOUJS9Ruck+1boQQeOutt/CHP/zB0byM8Qe9vrVY8vLyXC27V69elustrttrsnXu5b5666234ve//72nv6MQAg0NDUq3HGe6DVklW6rEmm55jNNH5dhIlK6f//znWLhwIQCgW7duWLduHUpKSkIuFZH6PG/RMiZZlZWVSbs25eTkYN68eV3mYTWK1c0336xfRdy8ebPXxU5gdeI1n0hVqSQEJSoViR07dgBIvn6klNiwYQPuvPPOpPMSQmDGjBn6/71790ZRUZE3BXUgPz8fBQUFkFKitbU17flo+5JWmY/KunQqVUXZywsFXidZmgEDBng+Tz9kGrtqyYnXSZ8KMSXT3NyMlpaWsItBEaQlWVJKNDY2oqysLGn9Lj8/H0eOHAm51ETh8zTRmjVrFoD/XbWcNGkSTpw4Ydu15vjx4zj33HNtd9T+/fvj73//OwBg9erVaGxsBICEyq9fsi2RsmO8RysKv8lXv/pVR+WUUur311jR3v/jH/+ov9fU1ISDBw96U9AUNm3ahJaWFtTX13s2zwEDBkBKiX79+ilfIXTK7qKIHxdGrr/+ejz88MMZzyeKrO61Tfdl7n4Xtky3jagcH2fMmIHTTz8dffv2tV03QR3f3AqqWzAlp+2zffr0wdq1a5MOWPavf/0LgwYNghACp512WthFJwqNp4nWk08+mbCjHTp0CN27d7edvnv37vpN4VaviooKXHLJJQnf6d+/v5dF7kLl7jthicrv8Z///MfV9Hb3WgghcOutt1rGvXz5cnz729/2qsi2qqqqfJv3xx9/7Nu8w2DVTdmuq28mNm3ahDlz5mQ8Hzv79u1TvvKYrGLl9KUK1X9rrx0/fhyvvPIKTp48abtuioqKMH369LCLqrNKzs29XZh4BcvpBZLCwkK0t7dDSom2tjauH8paSo8tXFhYiGPHjun/CyHw8ccf46abbvJ1uVYHbj8qbqpIdZKKSqx9+/ZN+/4R8+uxxx6znPaHP/yho3u7MvXTn/4UADB8+HDX3417pcOuYqX9bxW7ShV8OxdccIE+MIb5tXjx4rCLF0vGCy3psLowp+q+19DQgL59+yadRkqJLVu2BFQiZ5J1CbZLvMhfDzzwQMrf2bgujh8/jvb2dgghMGXKlCCK6Kl7773XUWv9tGnT8Pjjj2P9+vVYvHgxZs6ciUceeSTs4lPIlE60zLTWrDVr1vi2DONB3e7eDq/79YcpVQuealehw7Zo0SLMnTs3kGVp3S/cEELgxhtvRGtrq+2JcOPGjV4UL1RW3c+07TTK26vd1fuDBw/qJ/PPf/7zYRczVqxatp2wS+gzTd78smfPnoRHDACdMVx00UUJ76nSpdMtnquCc/fdd+uPprDa1mtra3H22WcD6BwgDQBycnIgpcTLL78cue3rl7/8paPW+h/96Ec4cOAA9u7dCwAoLS3FokWLcMcdd4QcgT1zsrhnz56wixQ7no86aNTe3o68vMRFZHogDOpAapVkJWvhiiJzkqX9H7c4vXT33XcH+pto60Nb5rvvvqtXlszlePbZZwEA69evTzrPmTNnxmq9WsUSty7AK1aswIoVKwAAkyZNil18KjC3ijj5fZO1tqhembQ63mvMx52w8Hykjscffxxz587FypUrAQAnTpxI+FwIgfLycnzxi1/E4MGDUVNTY7kdSdl5f74QAhUVFRg9enSgcfhp8uTJmDx5csJ7NTU1EEJg+fLlIZXKmrZfNTY2JtySM2rUKFRWVur/l5aWYu3atUEXL1Z8bdHShqTWXk899ZSnJ59Zs2bpXay8Yux+ZJVkxeWqmXk9mBNLc2tBtjHfvA90DmkbhoEDB+rPZCotLcU//vEPy+muueYaAMBdd92FkydPWk4zZMgQXHnllf4UNETmboN+7KPXXnstnnvuOc/n69bOnTtx7NixrN03/WbXk8HISRIS9fNEXl4eBg0aFNryre7PcvtdFVsWk7HqjqaKW265pctgQMYySikxduxYHD58GEDnxSEhBJqbm7vMq2fPnpCy8yHuKsWYDbR1dvDgQUgpu4x78N577yXsc9ro4XG7tztInidaHR0dtp+tXbsWOTneLXLdunV44IEHPJsfYN3vW8Ubub1gjieOMbo1ZMgQ/Z4YKSVKSkqQk5OTcMIP2qFDh9DS0oKOjg6Ul5fjc5/7nO20Ukr85je/QY8ePSzLWltbm/AQ8KgyV0aSdRt000KRzKZNmzBt2rSM5uEVJw9DjgpVKlpWldtMK7uqxGYn2X7R2tqKurq6gEuU+bPW7O7digpz+VVLuDRa5dvcfXvgwIEAgLlz50JKiV69etnOQ0qJhx9+WMn4NHv37sX48ePDLkbGtO3o+PHjkFJiyJAhjr63e/duSCkxYMAApdeTyjxNtK677jq8+OKL+v979+6FEAIPPvggnn/+eWzfvh3t7e2W3z1x4gReffVV2xW5dOlSL4ua1ZzsLNm4QwkhUFtbCyklFixYAADYsGGDfrJua2sLrWxSSuTm5uKSSy5JmfDZfS6EUKJFxgtOk14vW7jM3aCN7AaxSLUfZXIFe/PmzUlHdY0C1S7sWF1gA+wTezNVWyOOHj3aZVtxsg8F3XLqtAXLTZlU28bs2G1XqiZcCxYswIUXXggAqK6uRo8ePQC47zY7Z84c/Tvr1q3zpayZuPPOO/G73/0uo3n0798f77zzjkclck4b7VEIgdbWVkgp9fXklqrbYRR4mmhdfvnleO211/T/x44dCyklPvroIzz44INJT049e/bEr3/9a9t5/+QnP/GyqFnPTSU1m/z5z3+2fP/NN9/EZZddFnBpEkkpsXv37ozm8fWvf92j0oTHqiXWyFzR9buiJYRAbm6u7Q3SdvuRdtHJanonJ8Pp06dn9CBrcsauhcQuSVaxB8SPf/xjPPHEE66/F2TLqV23fSsq/bZecHKuNW97YVu8eDE++OADCCEwdOjQhHu2tOOYm+5mUkqUlpZiwoQJfhQ3ba+99houvvjijObR2NioJ6V+MyZX3bp1049FyS4UumE8T3k1z7jzNNEaM2YMysvLu7y/dOlSvPTSS5bfEULg7bffhpQSW7dudb3M0tJSPP30066/l62cdqGK24ksFe3EdfXVV1t+Xl9fn7QLRFA++eSTtE6yWpeBOAqysmtOnD788EP9fbe0e1itlmF3jx35w+k+ZW5xsXqpaM2aNbjhhhvCLkZSfv2GKiQlTjg9LztJ9oOSbJ1p3c3OPPNMV/NL1rMp6kpLS7s8MNxrxuTKz+NRFLvlhsXTROu8885z3TwqpcSFF16IAQMGpPUw4pkzZzLRcsjNDhG1nceLB8kmG4K1uLgY27dvz3gZmfrMZz6D4cOHp7V+0u0yoDLzCSVVK5JXyxRCYMyYMTjrrLNCq1wvWrQolOXGmSqtBZQ90rl/NCpJvpQSR44ccd3V89JLL9UHbAhCQ0MDysvLbQea8oKUEtOmTcP777/vqMdDOry4F9mNtrY2rF27lsfMFDxt9+vTpw8aGxtdf0/KzufE5ObmorCw0NV3R4wYgX379rleZrZKpzUr6J3XLa+6iP32t7+1fL+oqCij+Xrt/fffhxAClZWVGDlyJABgxowZ2Lx5c8J0xitOKq+/KJJS6g+T/uijj1wft+xUVVVhxIgRWLhwIVatWmU5zS233JJQDsqc1TGPOg0fPhw1NTX6c5GiRuXjoNvtLKju0F6SUuKOO+5w9fu/+uqrAPyP99prr8UzzzyD/v374/zzz0dzc7P+DCyNl8v+5je/6dm8zNKpe3uhtLQU3/3ud0NZdlQo08HyrLPOSut7eXl5vg5SEKUDWjIqnmQydfLkSfTo0QM7duzApEmTMp7fihUr8P3vfz/hvVGjRunDoKpEuxKmlWvz5s3635MnT8Z///tfAMD8+fNDK2PcVVVV4YknnsDgwYNTTmtXoTK/f8EFFwDoHLzg6NGjlt8J437VbEs8VNvfKb6S3btuN23UzufLly/HjTfe6LrcUkr87W9/8y3eZ555JlK/YzIFBQUpY2lubkbv3r0T3hs4cCAOHTqU0bLN9RFKpEyiRf7xopKk2k5UVlaGqVOn6qO9ZUIb7eg73/kOfvCDHyQkL5WVlUrFbVRcXIycnBx0dHSgsLAQQghcddVV2Llzp17mZcuWKVv+OLjppptw8803A7CuMB08eBBFRUWWnwkhsHHjRn2YXa27TFNTU5eTIfkjii0EbgkhsH///rCLkZFU5x/Vzk9OJDtvxfHCxrhx41BfX+96XX3pS1+CEAKzZ8/G6tWrfSyhvdraWkcX1MIihMDEiROTTlNUVGTZFbOurg5Dhw5FdXV1yuXU19ejuLhYH1ehrq5OvwcvPz8fQghP6mR+MZYryOOFp/do9e7du8vTwv1WV1enXNcuVaW78avW/1sIgalTp2bcv9k4VPOsWbMS+kwLIVBSUqJU3GZlZWV6+bRh6a+55pqEq55lZWVhFjErSCmxatUqy/t77JIs7Xtbt27FwoULsXDhQggh8Ne//lXJJEvl/SBdVgMLxNWwYcP0v7VYR4wY4ei7VVVV+PTTT/0qmi23AwakSlxU2obtEny7AX3M52Crc18Q229xcTH+8pe/dCmv09EFCwoK0NzcbFtWbcS8LVu2JLzf0dGBNWvWoKWlJe2yp0OL78tf/rL+t5t9wclAJbt27XI1YIjVMgDglVdesZ2mublZ75ljfM2ePRsAUFNTk3IZQgicccYZeOutt/RtUXtmGtD5KAgppf7cUdWY96sgj/meP7DYTHuWlpdBlZWV6fNraGjIaCPNBsaBAuxGKnL6Cltubi4A58PTm1/GoU+bmppsR0uSUgZ+0SAdra2tCevltttuA/C/YdyLi4tDKVe2mT17dkJl6L777nNUuVu3bh22bduGsrIyzJ8/P/RHCNhRYd/3i/nG9DjHKoRAnz59IKVEVVVVymm1bXjMmDEBlbCTm0EejPtZlNZdsgsw6SaFfieTjzzyCGbOnAkAKCkpwXnnnQcp3T3MtlevXjhx4oTl9NqIedOnT+/ymZQS+fn5gY3Iqm1XUkrU1NTof/fr18/196WUOP300y1jnjBhAo4cOZJWGa+44gr07t075Xq3m2bVqlWOH+HgdPAVKSWeffZZJY6l5rqr+WKF14OR2PG96+C4ceM8Pwh60ZqRrdI9EKvyW3d0dDhOsoD/xdvU1IQ+ffroB/K4sHuOxfPPPx+rOKNC2+4uv/xy1/ciqCxbjrfmc5Xb9aJay4mV1atXo1u3brafq9id0nwPiF1rjnk75b0j3ho2bBjq6uoAABs3bky7Mt29e3e9i5nb42QQ3dOSlcvJNiWEwHvvvZfw3tGjRzFy5EhPt0cnIyEvWbIk6efaQ8mNv+egQYNw4MAB9OjRA7/61a+Sfv/RRx/F9773vYT3pk2bBiklhgwZEsr+56aLYBDHCN9btIDOoGtraz2ZV0NDgz5PALjqqqvw1FNPeTLvbJKslUq1ViyN053hgw8+6PLeaaedFtuTrblykc0Vi7C3We0qmbF7DUVPJhcHVTp2TpkypctopN/61rewZcsW225rqnUV19i1OFp1qwvyarXfnMQQVpxuWx6N60/b1oxl379/P4QQ+n2vdsvMyfGv6pqfn4977rkn4/loIwIbVVZW2rZspUP7PSdMmIA//elPltMsWLDA0f5sXI+7du1Cz549IYTAz372s6TfmzNnjm0PqIceesjXY4ndcp1ukxq/jxW+t2hJKXHgwAFceuml6OjoyHh+xpFVhBDIycnxdaeLG6urfXasrg5GgTYMsbm899xzD0aPHh1GkQIjhMD48ePDLkYoorJ9UjQYzzPptE6qUMl/+eWX8dJLL+n/W8WhYguWHbctjirHZN6u7LYXJwmMk+lUIKXEggULMHLkSFRWVurvab/FsGHDHCcFfl1QbGlpwb333pv291OV6+jRownr+pNPPkl7Wdpy9uzZg5UrV+Ib3/hG2vMy0rqEalLVE8Pg5fo3J/9eCyRDGTZsGKqrqz098Wjzam9v92ye2SbV+lChouCl+++/HxUVFWEXwxfaiWfSpEnYvXt32MUhckXlY43bq51uLmaFaerUqRBCoL6+PhKVdLMollljbnHLtKuq6r/Fc889p/+9ZMkSPcnSpLOfvPDCC8ruW04JITBgwICM19+4ceOwdu1ay/uoDh8+DCFEl98c6Kybp5tcXH/99Vi6dGlG5U6X04sUbuYV+a6DXtiwYQMA4K677oIQAv/85z+VP7ioLspXA1Mxl/3RRx8NqSTBkVJix44dYReDyJUoHGfcVARVTq6AzouTQghs374dUkoUFBSEXSQCulQcrV7Gz8zfUdnVV18NoLPsr7/+uuU0bvebK6+8MuNybdiwIelv7GQ9ZPL9dOJ264wzzoCUEqNGjepSjkmTJqW9DW3atAnz5s3zuLSped2SFcQ+FJnnaJWUlETu4KIqpzu2ypUFO1Zl5nZDRJlyWyFS8XjDY6Ga7LYtu6v2UVx/qcqsJf5uKr+ZJiklJSUoKSlJeC/V8t9++2184QtfsJ0m1feDqtybZbJMq9/59ttvz7RIrtn9dul0JQ1yPfjSopUqmxdC4PDhw67nGYUm8ihI1R/VzQ2uKmpqakrY1pqamsIuEhHFULIr1cb3wnDfffdh2bJlCWWJ6jE9zozJr5P7sVRYf62trZ7Pc/78+Y5bhIyvsWPHel6WcePG2X6WLMlKJaih6f1grheuXLky0OU72fadNiAEvR95nmhZ9RE1v9ra2lBYWOh4R9q/f78SB5c4sEqizBWFqNm2bVvCzqM9M0J7OXnOBBFlzk0FKarHHWO5nZzvwjr2vPHGG5g3bx4TLIXZXeh0M33QpJTo3r07hBAoLCxMez7vvvtuwr60b9++hGWEtW9JKROe/zps2DD84he/QL9+/SCEcHQbwowZMyzf79GjhxLrMGqcJEZOL1Ro0wYplK6Dubm5HMRCMcakS9UDgV03gXPOOUfZMhPFiZOkKM77YlRimzdvHrZu3Ypt27bha1/7WtjFoRSidrFB2w927dqVdtmLiorQ2tpq+yzIMGnxaYM99OrVCxUVFRg8eLCj7xovII0ePRoVFRUQQqClpcW/QseQV4lR2F2m1dvCKVAqJ1ZWolRWojjhvhcdy5Yt07sNktqs9quoJF4TJ06M9XFh/vz5aX3P+Ju0tbVBCIEjR46gZ8+eXhUtawSVZPm5zzHRIl1UDu5EREREqsvLy4t1Muq3dOqlxt5PTn57vxscmGgRgPCbVomIiKgrXgSlbJTOLS1uB7sIoldXZJ6jRf5igkVERKQmnqOJnFEpyQLYopVV7K6KGd/nlTMiIoqCuJ+v4h4fURiC7sHFRCtL8GoYERHFRZy7u8cxJiIVhHHcYKJFREREkcFEhIjcMLYOZ8VztIiIiIiIiPwSZoKlYaJFRERERESxE3YLOEcdJCIiIiIi5bhJlMzThp1kAYBwUwghRD2AGv+K47mzpZSfTTZB3GKKWzwAY1IEY4oGxhQNcTuOA/GLKeu2O4AxKYIxRUPKmACXiRYRERERERGlxq6DREREREREHmOiRURERERE5DEmWkRERERERB5jokVEREREROQxJlpEREREREQeY6JFRERERETkMSZaREREREREHmOiRURERERE5DEmWkRERERERB77f/QhJ+gcY7JhAAAAAElFTkSuQmCC\n",
       "text/plain": [
        "<Figure size 1080x108 with 16 Axes>"
       ]
@@ -286,7 +278,8 @@
    "source": [
     "# Default optimizer, learning rate and number of epochs used in Xfer to train neural network\n",
     "DEFAULT_OPTIMIZER = 'sgd'\n",
-    "DEFAULT_OPTIMIZER_PARAMS = {'learning_rate': 0.001}  \n",
+    "DEFAULT_LEARNING_RATE = 0.01\n",
+    "DEFAULT_OPTIMIZER_PARAMS = {'learning_rate': DEFAULT_LEARNING_RATE}  \n",
     "DEFAULT_NUM_EPOCHS = 4\n",
     "\n",
     "TARGET_CLASS_COUNT = 4  # 4 classes of sketch images are used for this demo (car, cheese, house and tree)\n",
@@ -348,17 +341,17 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Learning rate is the hyperparameter we will optimize here\n",
-    "# We allow GPyOpt to operate in a normalized domain [0,1] and map the value to a desired log scale inside our objective function\n",
-    "# This helps GPyOpt to learn a smooth underlying function in fewer iterations\n",
-    "gpyopt_domain = [{'name': 'learning_rate', 'type': 'continuous', 'domain': (0,1)}]\n",
+    "# We allow emukit to operate in a normalized domain [0,1] and map the value to a desired log scale inside our objective function\n",
+    "# This helps emukit to learn a smooth underlying function in fewer iterations\n",
+    "from emukit.core import ParameterSpace, ContinuousParameter\n",
     "\n",
-    "# Method to map a value given by GPyOpt in [0, 1] to a desired range of learning rate\n",
+    "emukit_param_space = ParameterSpace([ContinuousParameter('learning_rate', 0, 1)])\n",
+    "\n",
+    "# Method to map a value given by emukit in [0, 1] to a desired range of learning rate\n",
     "def map_learning_rate(source_value):\n",
     "    if(source_value < 0 or source_value > 1):\n",
     "        raise ValueError('source_value must be in the range [0,1]')\n",
@@ -385,24 +378,23 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def get_hyperparameters_from_config(config):\n",
     "    \"\"\" \n",
-    "    Extract hyperparameters from input configuration provided by GPyOpt.\n",
+    "    Extract hyperparameters from input configuration provided by emukit.\n",
     "    Refer the caller 'hpo_objective_function' for more details.\n",
     "    \"\"\"\n",
-    "    learning_rate = map_learning_rate(config[0]) # Map learning_rate value given by GPyOpt to the desire range\n",
+    "    learning_rate = map_learning_rate(config[0]) # Map learning_rate value given by emukit to the desire range\n",
     "    optimizer = DEFAULT_OPTIMIZER  # Using default optimizer here i.e. 'sgd'\n",
     "    return optimizer, learning_rate\n",
     "\n",
     "def hpo_objective_function(config_matrix):\n",
     "    \"\"\" \n",
     "    Objective function to optimize the hyperparameters for\n",
-    "    This method is called by GPyOpt internally to get outputs of objective function for different input configurations\n",
+    "    This method is called by emukit during the optimization loop\n",
+    "    to get outputs of objective function for different input configurations\n",
     "    \n",
     "    We train a neural network with given hyperparameters and return (1-precision) on validation data as the output\n",
     "    You can choose to optimize for a different measure and create the objective function accordingly\n",
@@ -439,7 +431,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### iii) Initialize a Bayesian optimizer using GPyOpt"
+    "#### iii) Define a model using GPy for emukit to optimize"
    ]
   },
   {
@@ -448,61 +440,97 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "learning_rate: 9.069790423538591e-06. optimizer: sgd. precision: 0.3333333333333333\n",
-      "learning_rate: 0.0012898638021921914. optimizer: sgd. precision: 0.25\n"
-     ]
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "set_random_seeds()\n",
-    "NUM_INITIAL_POINTS = 2\n",
-    "hyperparameter_optimizer = GPyOpt.methods.BayesianOptimization(f=hpo_objective_function, \n",
-    "                                                               domain=gpyopt_domain, \n",
-    "                                                               initial_design_numdata=NUM_INITIAL_POINTS)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### iv) Run more iterations to identify a better learning rate for our objective function"
+    "# Notice that our initial learning rate value corresponds to 0.8 on [0, 1] scale\n",
+    "map_learning_rate(0.8) == DEFAULT_LEARNING_RATE"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 9,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "learning_rate: 9.013709494113845e-06. optimizer: sgd. precision: 0.3333333333333333\n",
-      "learning_rate: 1e-06. optimizer: sgd. precision: 0.0\n",
-      "learning_rate: 5.7283938954731085e-05. optimizer: sgd. precision: 0.8333333333333334\n",
-      "learning_rate: 9.561628676496412e-05. optimizer: sgd. precision: 0.75\n",
-      "learning_rate: 0.1. optimizer: sgd. precision: 0.25\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "set_random_seeds()\n",
-    "NUM_ITERATIONS_TO_RUN = 5\n",
-    "hyperparameter_optimizer.run_optimization(max_iter = NUM_ITERATIONS_TO_RUN)"
+    "\n",
+    "import GPy\n",
+    "X = np.array([[0.8]])\n",
+    "Y = np.array([[1.0 - precision_default]])\n",
+    "\n",
+    "gpy_model = GPy.models.GPRegression(X, Y)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The command below can be used to plot and visualize the different learning rates explored by GPyOpt in the normalized domain [0, 1]. Note that it's currently not executed as part of the notebook due to plotting issues in GPyOpt ([link](https://github.com/SheffieldML/GPyOpt/issues/215)). Related issue in GPy [here](https://github.com/SheffieldML/GPy/issues/728).\n",
+    "#### iv) Initialize a Bayesian optimizer using emukit"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from emukit.bayesian_optimization.loops import BayesianOptimizationLoop\n",
+    "from emukit.model_wrappers import GPyModelWrapper\n",
     "\n",
-    "``` python\n",
-    "hyperparameter_optimizer.plot_acquisition()\n",
-    "```"
+    "emukit_model = GPyModelWrapper(gpy_model)\n",
+    "hyperparameter_optimizer = BayesianOptimizationLoop(emukit_param_space, emukit_model)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### v) Run optimization loop to identify a better learning rate for our objective function"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Optimization restart 1/1, f = 1.1312564608151783\n",
+      "learning_rate: 1e-06. optimizer: sgd. precision: 0.5\n",
+      "Optimization restart 1/1, f = 0.9815790760721594\n",
+      "learning_rate: 1e-06. optimizer: sgd. precision: 0.5\n",
+      "Optimization restart 1/1, f = -6.963249113616735\n",
+      "learning_rate: 1.604696232278503e-06. optimizer: sgd. precision: 0.5\n",
+      "Optimization restart 1/1, f = -9.048731845639432\n",
+      "learning_rate: 1.2681487716415876e-06. optimizer: sgd. precision: 0.5\n",
+      "Optimization restart 1/1, f = -16.18851622078782\n",
+      "learning_rate: 1.260324119615607e-06. optimizer: sgd. precision: 0.5\n",
+      "Optimization restart 1/1, f = -24.10206487648798\n",
+      "learning_rate: 6.481443855100692e-06. optimizer: sgd. precision: 0.6666666666666666\n",
+      "Optimization restart 1/1, f = -19.418706806972033\n",
+      "learning_rate: 7.474320732444072e-05. optimizer: sgd. precision: 0.8333333333333334\n",
+      "Optimization restart 1/1, f = -19.008643512409204\n"
+     ]
+    }
+   ],
+   "source": [
+    "NUM_ITERATIONS_TO_RUN = 7\n",
+    "\n",
+    "hyperparameter_optimizer.run_loop(hpo_objective_function, NUM_ITERATIONS_TO_RUN)\n",
+    "results = hyperparameter_optimizer.get_results()"
    ]
   },
   {
@@ -514,23 +542,73 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Optimized learning rate: 5.7283938954731085e-05. Precision on validation data: 0.8333333333333334\n"
+      "Optimized learning rate: 7.474320732444072e-05. Precision on validation data: 0.8333333333333334\n"
      ]
     }
    ],
    "source": [
     "# Take hyperparameters that minimized the objective function output\n",
-    "x_best = hyperparameter_optimizer.X[np.argmin(hyperparameter_optimizer.Y)]\n",
+    "x_best = results.minimum_location\n",
     "optimized_learning_rate = map_learning_rate(x_best[0])\n",
-    "precision = 1.0 - min(hyperparameter_optimizer.Y)[0]  # Objective was to minimize 1-precision \n",
+    "precision = 1.0 - results.minimum_value  # Objective was to minimize 1-precision \n",
     "print('Optimized learning rate: {}. Precision on validation data: {}'.format(optimized_learning_rate, precision))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style type=\"text/css\">\n",
+       ".pd{\n",
+       "    font-family: \"Courier New\", Courier, monospace !important;\n",
+       "    width: 100%;\n",
+       "    padding: 3px;\n",
+       "}\n",
+       "</style>\n",
+       "\n",
+       "<p class=pd>\n",
+       "<b>Model</b>: GP regression<br>\n",
+       "<b>Objective</b>: -19.008643512409204<br>\n",
+       "<b>Number of Parameters</b>: 3<br>\n",
+       "<b>Number of Optimization Parameters</b>: 3<br>\n",
+       "<b>Updates</b>: True<br>\n",
+       "</p>\n",
+       "<style type=\"text/css\">\n",
+       ".tg  {font-family:\"Courier New\", Courier, monospace !important;padding:2px 3px;word-break:normal;border-collapse:collapse;border-spacing:0;border-color:#DCDCDC;margin:0px auto;width:100%;}\n",
+       ".tg td{font-family:\"Courier New\", Courier, monospace !important;font-weight:bold;color:#444;background-color:#F7FDFA;border-style:solid;border-width:1px;overflow:hidden;word-break:normal;border-color:#DCDCDC;}\n",
+       ".tg th{font-family:\"Courier New\", Courier, monospace !important;font-weight:normal;color:#fff;background-color:#26ADE4;border-style:solid;border-width:1px;overflow:hidden;word-break:normal;border-color:#DCDCDC;}\n",
+       ".tg .tg-left{font-family:\"Courier New\", Courier, monospace !important;font-weight:normal;text-align:left;}\n",
+       ".tg .tg-center{font-family:\"Courier New\", Courier, monospace !important;font-weight:normal;text-align:center;}\n",
+       ".tg .tg-right{font-family:\"Courier New\", Courier, monospace !important;font-weight:normal;text-align:right;}\n",
+       "</style>\n",
+       "<table class=\"tg\"><tr><th><b>  GP_regression.         </b></th><th><b>                 value</b></th><th><b>constraints</b></th><th><b>priors</b></th></tr>\n",
+       "<tr><td class=tg-left>  rbf.variance           </td><td class=tg-right>    0.2277492329864631</td><td class=tg-center>    +ve    </td><td class=tg-center>      </td></tr>\n",
+       "<tr><td class=tg-left>  rbf.lengthscale        </td><td class=tg-right>   0.14749782910704992</td><td class=tg-center>    +ve    </td><td class=tg-center>      </td></tr>\n",
+       "<tr><td class=tg-left>  Gaussian_noise.variance</td><td class=tg-right>1.5082311499773513e-15</td><td class=tg-center>    +ve    </td><td class=tg-center>      </td></tr>\n",
+       "</table>"
+      ],
+      "text/plain": [
+       "<GPy.models.gp_regression.GPRegression at 0x13beecc88>"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "gpy_model"
    ]
   },
   {
@@ -549,19 +627,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Optimized learning rate: 5.7283938954731085e-05. Precision on test data: 0.9375\n"
+      "Optimized learning rate: 7.474320732444072e-05. Precision on test data: 0.9375\n"
      ]
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA1oAAABNCAYAAAC/mRUgAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvOIA7rQAAIABJREFUeJzt3X94FNW9P/D3J/wIBAH5UYQAAVT4QtFii4itgBeqpljxIq01WGkULrZIW22h8HhrtVqqIGCLgqIF5EEtXPxWREViQVSqlgvEHxRraiwkpPxMAmJDAgRy7h+7s85uZnZndmd3fuz79Tz7PMnszOw5M+ecmc+cMzOilAIRERERERE5J8ftBBAREREREQUNAy0iIiIiIiKHMdAiIiIiIiJyGAMtIiIiIiIihzHQIiIiIiIichgDLSIiIiIiIoc5FmiJyK0i8rZT6yPniEiFiFzldjrIGtYlyrQgthFBzJOGbYR3sdwROScI9Yk9WjYEYYcTeQHrEhGZYftAREHBQMshItLS7TSQs7hP3cHtzm1AZIZ1g/wiiGU1iHlKt6QCLRHpLSIviEi1iNSKyGLddwtE5JiI7BWRsbrpHUVkuYgcFJH9IjJHRFrovp8sIh+Hl31NRPqEp4uI/E5EjojI5yLyNxG5KPxdbvj39onIYRFZKiJtk98ccfP8DIACAC+LSJ2IzBIRJSJTRGQfgC3h+S4XkXdF5DMR+VBE/sPqNkizS0Rkl4gcF5H/EZE24TRNFZFPReSoiLwkIvnh6X3D+YtUKhF5U0T+K/z3hSLyVnh9NSLyP7r5BorIpvA6/yEi38tQHqMYlVMRuUBEtoT/rxGR50TkXN0yFSIyW0R2ATiR7kaFdcmXdSkhP5Q9A0FsI3yfp2xrIwLSPrDc+azcWd0G4v12PC6f5snf9UkpZesDoAWADwH8DkA7AG0AjABwK4BGAFPD80wDcACAhJdbB+DJ8DLdAGwH8MPwd/8J4FMAgwC0BHAPgHfD3xUCKAVwLgAJz9Mj/N3vALwEoDOA9gBeBvCQ3TzZyHsFgKvCf/cFoACsCuepLYCeAGoBXItQEHt1+P8vJdoG6fyE070dQH54W30M4EcAxgCoAfA1ALkAHgOwNSZ/LXXreRPAf4X/Xg3gl+F8tgEwIjy9HYAqALeF9+VXw7/x5XTn02I5vTC8X3IBfAnAVgC/j9lWHwDoDaCtS2lkXfJoXQpK2TPZH4FqI4KQpzhl6VYEuI2Aj9sHljv/ljuL28Cz7XgQ8xSI+pREpr8OoFqfgfD0WwF8qvs/L5zR7gDOA3BKv4MATATwRvjvjQCm6L7LAVAPoE94Y34C4HIAObp5BMAJABfEpG1vmnd4bON/vu772QCeiVnmNQDFibZBBgrqLbr/HwawFMByAA/rpp+DUCPa10JBXQXgKQC9Yn7rJgB/iZn2JID70p1PK+XUYL7xAN6P2VaT3Uwj65J361JQyp7J/ghUGxGEPJmVJQS8jYCP2weWO/+WOyvbwGA+z7TjQcxTEOpTMkMHewOoVEqdMfjukPaHUqo+/Oc5CFWkVgAOhrv5Pwsnvlt4nj4AFum+O4pQBeuplNoCYDGAJQCOiMhTItIBoag7D0CpbrmS8PRMqtL93QfAjVp6wmkaAaAHEm+DdDuk+7seof2SD6BSm6iUqkPoqmBPC+ubhdA+2i4iH4nI5PD0PgCGx2yD7yPUEGeSYTkVkfNEZE14WMPnAJ4F0DVm2SpkButSNL/UpUT8UPaMBLGN8Hue2EZ8wU/tA8ud/8udX9vxePyaJ1/Xp2TGWVYBKBCRliaV0GyZUwC6mixTBeC3SqnnjBZWSj0K4FER6QZgLYBfALgPQAOAwUqp/XYzkSSVYFoVQlfZpsbOJCI9EH8buOEAQgULACAi7QB0AbAfoatIQKiR+zz8d6SwKaUOITR8ACIyAsBmEdmK0DZ4Syl1ddpTH59ZOX0QoX12sVLqqIiMR6iB1zPaz5lMY6JlWJe8V5f0/FD2rApiG+GnPGVrGxHE9oHlzvvlTi9I7bgmSHnyTX1KpkdrO4CDAOaKSDsRaSMiV8RbQCl1EMCfASwUkQ4ikiOhm++uDM+yFMDdIjIYiNxQeWP472EiMlxEWiG08U4CaFJKNQH4A4DfhSsmRKSniBQmkSerDgM4P873zwIYJyKFItIivG3+Q0R6WdgGblgN4DYRuUREchGqbP+rlKpQSlUjVGBvCedlMoALtAVF5EYR6RX+9xhClbAJwCsABojIJBFpFf4ME5FBGc2ZeTltD6AOwHER6YlQY+4W1iVzfqtLen4oe1YFsY3wU56ytY0IYvvAcuf9cqcXpHZcE6Q8+aY+2Q60lFJnAYxD6Oa5fQD+hdC4xkR+AKA1gL8jlLH/j1A3P5RS6wDMA7BGQt2WuwFoT7LpgFBFO4ZQN2EtgPnh72YjdHPltvBymwH8P7t5suEhAPdIqDvxu7FfKqWqELrh878RGgdbhVCB1baz6TZwg1JqM4BfAfgTQpXvAgBFulmmIpT+WgCDAbyr+24YgP8VkTqEblS9Uym1Ryn1bwDXhNdzAKEu33kI3ayYMXHK6f0I3Tx5HMAGAC9kMl0W05gI65LH6pKeH8qeVUFsI/yUpyxuIwLXPrDc+aLcRQSpHdcEKU9+qk/ak2KIiIiIiIjIIXxhMRERERERkcMYaBERERERETmMgRYREREREZHDGGgRERERERE5zNZ7tLp27ar69u2bpqQ4r6KiAjU1NRJvnqDlKWj5AZgnL2Ce/MGNPJWWlmLo0KGOrS9WNu4nv+UHAEpLS2uUUqYvkvVbnrKx3AHMkxcwT/5gJU+AzUCrb9++2LlzZ/KpyrBLL7004TxBy1PQ8gMwT17APPlDpvMkEjrGlJaWRqY5/SRbN/aTiDieD72gteMAICKV8b73W57YPvgD8+QP2ZongEMHiYgoBUqpyAf4IvjyKy39fs8HERG5LyOBloik7UNE5HVKKQwaNCjSbt18881uJyllRr0+WsDl1/ZZS7M+aPRjPoiIyBvSHmhpB2OnP1u3bk1rmhnURcv2/BPZpW87cnJy8Pzzz0farxEjRkSm+1GioXX6gMtvtHzpjzc8DhARUTLSepTXH4ydPFCJCEaNGpXyeuKJDeyylbbPsnkbeNW0adPY2+uyRYsWmW7/EydORLUhF110UWS5O+64A0optG7d2nf7yk56/dS7FS+NsUMjjeb1Qx6JiCiz0hJo/fOf/0zp5Fx/svLaa69Fpj/22GNRJzDpYnYlNhtPYv06hOayyy4zPQGeP3++rXV5Ie/vvfdes3wMGDDAtMe3vr4+Ml9FRYWrac+UTAWc+m1bXl5uug/y8vISruvkyZNoampyvXxZFTu0zgo/tCFW82XWy+XVfBERkbtsPXXQiu3bt2P48OGGY/eTUVhYCCC5A3yq9MFi7O+6kR63+O0m90T7RkTw/vvv449//KOldenzn+n9reWlZcuWtn67bdu2hvstqOU13j53sq7efvvt+MMf/uDodhQR1NTUeLrnONUyZBRseSWvyaZHP79f2kaiZP3qV7/CnDlzAACtWrXCqlWrUFRU5HKqiLzP8R4tfZBVVlYWd2hTTk4OZsyY0WwdRk+xmjx5cuQq4rp165xOdhSjA2/sgdQrJwmZ4pcTiS1btgCIv3+UUli9ejXuuuuuuOsSEUyYMCHyf7t27VBQUOBMQi3Iy8tD165doZRCY2Nj0uvR6pJ2Mu+XfWlVohNlJy8UOB1kabp06eL4OtMh1bx7LThxOujzQp7iqa+vR0NDg9vJIB/SgiylFGpra1FSUhL3/C4vLw9HjhxxOdVE7nM00Jo0aRKAL65ajh49GqdOnTIdWnPy5ElccMEFphW1c+fO+Nvf/gYAWL58OWprawEg6uQ3XbItkDKjv0fLD9vkm9/8pqV0KqUi99cY0ab/6U9/ikyrq6tDVVWVMwlNYO3atWhoaEB1dbVj6+zSpQuUUujUqZPnTwitMrsoko4LIzfddBMef/zxlNfjR0b32ib7iR1+57ZUy4Zf2scJEyagQ4cO6Nixo+m+yVT7ZlemhgVTfFqdbd++PVauXBn3gWWffvopevToARHBOeec43bSiVzjaKD17LPPRlW0gwcPonXr1qbzt27dOnJTuNFn9+7duPzyy6OW6dy5s5NJbsbLw3fc4pft8fnnn9ua3+xeCxHB7bffbpjvRYsW4fvf/75TSTZVXl6etnUfPXo0bet2g9EwZbOhvqlYu3Ytpk2blvJ6zOzatcvzJ4/xTqysfrzC69vaaSdPnsRbb72F06dPm+6bgoICjB8/3u2kRhgF57GjXRh4ZZbVCyT5+fk4e/YslFI4c+YM9w9lLU8/Wzg/Px8nTpyI/C8iOHr0KG677ba0/q5Rw52OEzevSHSQ8kteO3bsmPT9I7GfJ5980nDen/70p5bu7UrVL3/5SwBA//79bS8b9JMOsxMr7X+jvHvpBN/MxRdfHHkwRuxn3rx5bicvkPQXWpJhdGHOq3WvpqYGHTt2jDuPUgrr16/PUIqsiTck2CzwovR68MEHE25n/b44efIkzp49CxHBVVddlYkkOur++++31Fs/btw4PPXUU3jmmWcwb948TJw4EU888YTbySeXeTrQiqX1Zq1YsSJtv6Fv1M3u7XB6XL+bEvXgee0qtNvmzp2L6dOnZ+S3tOEXdogIbrnlFjQ2NpoeCNesWeNE8lxlNPxMK6d+Lq9mV++rqqoiB/OvfOUrbiczUIx6tq0wC+hTDd7SZceOHVGvGABCebj00kujpnllSKddPFZlzt133x15NYVRWd+/fz/69OkDIPSANADIycmBUgqvv/6678rXr3/9a0u99T/72c+wd+9e7Ny5EwBQXFyMuXPn4s4773Q5B+Zig8UdO3a4naTAcfypg3pnz55Fy5bRP5FqQ5iphtQoyIrXw+VHsUGW9n/Q8umku+++O6PbRNsf2m9+9NFHkZOl2HS89NJLAIBnnnkm7jonTpwYqP1qlJegDQFevHgxFi9eDAAYPXp04PLnBbG9Ila2b7zeFq+fTBq195rYdsctPB55x1NPPYXp06djyZIlAIBTp05FfS8iKC0txde+9jX07NkTlZWVhuVIqdD9+SKC3bt3Y/DgwRnNRzqNGTMGY8aMiZpWWVkJEcGiRYtcSpUxrV7V1tZG3ZIzaNAglJWVRf4vLi7GypUrM528QElrj5b2SGrt89xzzzl68Jk0aVJkiJVT9MOPjIKsoFw1i90PsYFlbG9Btom9eR8IPdLWDd27d4+8k6m4uBh///vfDee7/vrrAQCzZ8/G6dOnDefp1asXrrnmmvQk1EWxwwbTUUdvuOEGvPLKK46v16433ngDJ06cyNq6mW5mIxn0rAQhfj9OtGzZEj169HDt943uz7K7rBd7FuMxGo7mFVOnTm32MCB9GpVSGDp0KA4fPgwgdHFIRFBfX99sXW3atIFSoZe4eymP2UDbZ1VVVVBKNXvuwccffxxV57Snhwft3u5McjzQampqMv1u5cqVyMlx7idXrVqFBx980LH1Acbjvr14I7cTYvMTxDza1atXr8g9MUopFBUVIScnJ+qAn2kHDx5EQ0MDmpqaUFpaii9/+cum8yql8PDDDyM3N9cwrfv37496CbhfxZ6MxBs2aKeHIp61a9di3LhxKa3DKVZehuwXXjnRMjq5TfVk1yt5MxOvXjQ2NuLQoUMZTlHq71ozu3fLL2LT77WAS6OdfMcO3+7evTsAYPr06VBKoW3btqbrUErh8ccf92T+NDt37sTw4cPdTkbKtHJ08uRJKKXQq1cvS8tt27YNSil06dLF0/vJyxwNtG688Ub8+c9/jvy/c+dOiAgeeeQRvPrqq9i0aRPOnj1ruOypU6fw9ttvm+7IBQsWOJnUrGalsmRjhRIR7N+/H0opzJo1CwCwevXqyMH6zJkzrqVNKYUWLVrg8ssvTxjwmX0vIp7okXGC1aDXyR6u2GHQemYPsUhUj1K5gr1u3bq4T3X1A69d2DG6wAaYB/axvNobcfz48WZlxUodynTPqdUeLDtp8loZM2NWrrwacM2aNQuXXHIJAKCiogK5ubkA7A+bnTZtWmSZVatWpSWtqbjrrrvw6KOPprSOzp0748MPP3QoRdZpT3sUETQ2NkIpFdlPdnm1HPqBo4HWlVdeiXfeeSfy/9ChQ6GUwoEDB/DII4/EPTi1adMGDz30kOm6f/GLXziZ1Kxn5yQ1m7z88suG09977z2MGDEiw6mJppTCtm3bUlrHt7/9bYdS4x6jnli92BPddJ9oiQhatGhheoO0WT3SLjoZzW/lYDh+/PiUXmRN1pj1kJgFyV4cAfHzn/8cTz/9tO3lMtlzajZs34iXtq0TrBxrY8ue2+bNm4d9+/ZBRNC3b9+oe7a0dszOcDOlFIqLizFy5Mh0JDdp77zzDi677LKU1lFbWxsJStNNH1y1atUq0hbFu1Boh/445dQ6g87RQGvIkCEoLS1tNn3BggXYvHmz4TIigg8++ABKKWzYsMH2bxYXF+P555+3vVy2sjqEKmgHskS0A9d1111n+H11dXXcIRCZcuzYsaQOstqQgSDK5MlubOD0r3/9KzLdLu0eVqPfMLvHjtLDap2K7XEx+njRihUrcPPNN7udjLjStQ29EJRYYfW4bCXYz5R4+0wbbnbeeefZWl+8kU1+V1xc3OyF4U7TB1fpbI/8OCzXLY4GWhdeeKHt7lGlFC655BJ06dIlqZcRT5w4kYGWRXYqhN8qjxMvko33CNbCwkJs2rQp5d9I1bnnnov+/fsntX+SHTLgZbEHlES9SE79pohgyJAh6N27t2sn13PnznXld4PMK70FlD2SuX/UL0G+UgpHjhyxPdTziiuuiDywIRNqampQWlpq+qApJyilMG7cOHzyySeWRjwkw4l7ke04c+YMVq5cyTYzAUf7/dq3b4/a2lrbyykVek9MixYtkJ+fb2vZAQMGYNeuXbZ/M1sl05uV6cprl1NDxH7/+98bTi8oKEhpvU775JNPICIoKyvDwIEDAQATJkzAunXroubTX3Hy8v7zI6VU5GXSBw4csN1umSkvL8eAAQMwZ84cLFu2zHCeqVOnRqWDUmfU5lFI//79UVlZGXkvkt94uR20W84yNRzaSUop3Hnnnba2/9tvvw0g/fm94YYb8OKLL6Jz58646KKLUF9fH3kHlsbJ3/7ud7/r2LpiJXPu7YTi4mLceuutrvy2X3hmgGXv3r2TWq5ly5ZpfUiBnxq0eLx4kEnV6dOnkZubiy1btmD06NEpr2/x4sX48Y9/HDVt0KBBkcegeol2JUxL17p16yJ/jxkzBv/+978BADNnznQtjUFXXl6Op59+Gj179kw4r9kJVez0iy++GEDo4QXHjx83XMaN+1WzLfDwWn2n4Ip377rZvH47ni9atAi33HKL7XQrpfDXv/41bfl98cUXfbUd4+natWvCvNTX16Ndu3ZR07p3746DBw+m9Nux5yMUzTOBFqWPEydJXqtEJSUlGDt2bORpb6nQnnb0gx/8AD/5yU+igpeysjJP5VuvsLAQOTk5aGpqQn5+PkQE1157Ld54441ImhcuXOjZ9AfBbbfdhsmTJwMwPmGqqqpCQUGB4XcigjVr1kQes6sNl6mrq2t2MKT08GMPgV0igj179ridjJQkOv547fhkRbzjVhAvbAwbNgzV1dW299XXv/51iAimTJmC5cuXpzGF5vbv32/pgppbRASjRo2KO09BQYHhUMxDhw6hb9++qKioSPg71dXVKCwsjDxX4dChQ5F78PLy8iAijpyTpYs+XZlsLxy9R6tdu3bN3haebocOHfLc0C6vSrbwe238t4hg7NixKY9v1j+qedKkSVFjpkUERUVFnsp3rJKSkkj6tMfSX3/99VFXPUtKStxMYlZQSmHZsmWG9/eYBVnachs2bMCcOXMwZ84ciAj+8pe/eDLI8nI9SJbRgwWCql+/fpG/tbwOGDDA0rLl5eX47LPP0pU0U3YfGJAocPFSGTYL8M0e6BN7DDY69mWi/BYWFuLNN99sll6rTxfs2rUr6uvrTdOqPTFv/fr1UdObmpqwYsUKNDQ0JJ32ZGj5+8Y3vhH5205dsPKgkq1bt9p6YIjRbwDAW2+9ZTpPfX19ZGSO/jNlyhQAQGVlZcLfEBF069YN77//fqQsau9MA0KvglBKRd476jWx9SqTbb7jLyyOpb1Ly8lMlZSURNZXU1OTUiHNBvoHBZg9qcjqx20tWrQAYP3x9LEf/aNP6+rqTJ+WpJTK+EWDZDQ2Nkbtlx/+8IcAvniMe2FhoSvpyjZTpkyJOhl64IEHLJ3crVq1Chs3bkRJSQlmzpzp+isEzHih7qdL7I3pQc6riKB9+/ZQSqG8vDzhvFoZHjJkSIZSGGLnIQ/6euanfRfvAkyyQWG6g8knnngCEydOBAAUFRXhwgsvhFL2Xmbbtm1bnDp1ynB+7Yl548ePb/adUgp5eXkZeyKrVq6UUqisrIz83alTJ9vLK6XQoUMHwzyPHDkSR44cSSqNV199Ndq1a5dwv5vNs2zZMsuvcLD68BWlFF566SVPtKWx566xFyucfhiJmbQPHRw2bJjjjaATvRnZKtmG2CvbuqmpyXKQBXyR37q6OrRv3z7SkAeF2XssXn311UDl0y+0cnfllVfavhfBy7KlvY09VtndL17rOTGyfPlytGrVyvR7Lw6njL0HxKw3J7ac8t4RZ/Xr1w+HDh0CAKxZsybpk+nWrVtHhpjZbSczMTwtXrqslCkRwccffxw17fjx4xg4cKCj5dHKk5Dnz58f93vtpeT67dmjRw/s3bsXubm5+O1vfxt3+aVLl+JHP/pR1LRx48ZBKYVevXq5Uv/sDBHMRBuR9h4tIJTp/fv3O7KumpqayDoB4Nprr8Vzzz3nyLqzSbxeKq/1YmmsVoZ9+/Y1m3bOOecE9mAbe3KRzScWbpdZ7SqZfngN+U8qFwe91HZeddVVzZ5G+r3vfQ/r1683HbbmtaHiGrMeR6NhdZm8Wp1uVvLgVj7t9jzq959W1vRp37NnD0Qkct+r2W/m5KTv1DUvLw/33ntvyuvRngisV1ZWZtqzlQxte44cORIvvPCC4TyzZs2yVJ/1+3Hr1q1o06YNRAT33HNP3OWmTZtmOgLqscceS2tbYva7VsukJt1tRdp7tJRS2Lt3L6644go0NTWlvD79k1VEBDk5OWmtdEFjdLXPjNHVQT/QHkMcm957770XgwcPdiNJGSMiGD58uNvJcIVfyif5g/44k0zvpBdO8l9//XVs3rw58r9RPrzYg2XGbo+jl/MUW67MyouVAMbKfF6glMKsWbMwcOBAlJWVRaZp26Jfv36Wg4J0XVBsaGjA/fffn/TyidJ1/PjxqH197NixpH9L+50dO3ZgyZIl+M53vpP0uvS0IaGaROeJbnBy/8cG/07LSITSr18/VFRUOHrg0dZ19uxZx9aZbRLtDy+cKDjpN7/5DXbv3u12MtJCO/CMHj0a27Ztczs5RLZ4ua2xe7XTzsUsN40dOxYigurqal+cpMfyY5o1sT1uqQ5V9fq2eOWVVyJ/z58/PxJkaZKpJ6+99ppn65ZVIoIuXbqkvP+GDRuGlStXGt5HdfjwYYhIs20OhM7Nkw0ubrrpJixYsCCldCfL6kUKO+vy/dBBJ6xevRoAMHv2bIgI/vGPf3i+cfE6P18NTCQ27UuXLnUpJZmjlMKWLVvcTgaRLX5oZ+ycCHo5uAJCFydFBJs2bYJSCl27dnU7SQQ0O3E0+ui/i13Gy6677joAobS/++67hvPYrTfXXHNNyulavXp13G1sZT+ksnwy+barW7duUEph0KBBzdIxevTopMvQ2rVrMWPGDIdTm5jTPVmZqEO+eY9WUVGR7xoXr7Jasb18smDGKM0sN0SUKrsnRF5sb9gWepNZ2TK7au/H/ZcozVrgb+fkN9UgpaioCEVFRVHTEv3+Bx98gK9+9aum8yRaPlMn97FS+U2j7XzHHXekmiTbzLZdMkNJM7kf0tKjlSiaFxEcPnzY9jr90EXuB4nGo9q5wdWL6urqospaXV2d20kiogCKd6VaP80NDzzwABYuXBiVFr+26UGmD36t3I/lhf3X2Njo+DpnzpxpuUdI/xk6dKjjaRk2bJjpd/GCrEQy9Wj6dIg9L1yyZElGf99K2bfagZDpeuR4oGU0RjT2c+bMGeTn51uuSHv27PFE4xIERkFU7ImC32zcuDGq8mjvjNA+Vt4zQUSps3OC5Nd2R59uK8c7t9qe7du3Y8aMGQywPMzsQqed+TNNKYXWrVtDRJCfn5/0ej766KOourRr166o33Crbimlot7/2q9fP9x3333o1KkTRMTSbQgTJkwwnJ6bm+uJfeg3VgIjqxcqtHkzyZWhgy1atOBDLDxGH3R5tSEwGyZw/vnnezbNREFiJSgKcl30S95mzJiBDRs2YOPGjfjWt77ldnIoAb9dbNDqwdatW5NOe0FBARobG03fBekmLX/awx7atm2L3bt3o2fPnpaW1V9AGjx4MHbv3g0RQUNDQ/oSHUBOBUZuD5n2XgmnjPJyYGXET2klChLWPf9YuHBhZNggeZtRvfJL4DVq1KhAtwszZ85Majn9Njlz5gxEBEeOHEGbNm2cSlrWyFSQlc46x0CLIvzSuBMRERF5XcuWLQMdjKZbMuel+tFPVrZ9ujscGGgRAPe7VomIiKg5XgSlbJTMLS12H3aRiVFdvnmPFqUXAywiIiJv4jGayBovBVkAe7SyitlVMf10XjkjIiI/CPrxKuj5I3JDpkdwMdDKErwaRkREQRHk4e5BzBORF7jRbjDQIiIiIt9gIEJEduh7h7PiPVpERERERETp4maApWGgRUREREREgeN2DzifOkhERERERJ5jJ1CKndftIAsAxE4iRKQaQGX6kuO4PkqpL8WbIWh5Clp+AObJI5gnf2Ce/CFo7TgQvDxlXbkDmCePYJ78IWGeAJuBFhERERERESXGoYNEREREREQOY6BFRERERETkMAZaREREREREDmOgRURERERE5DAGWkRERERERA5joEVEREREROQwBlpEREREREQOY6BFRERERETkMAZaRERWOe2HAAAAC0lEQVREREREDvs/3vNXia/MIw0AAAAASUVORK5CYII=\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA1oAAABNCAYAAAC/mRUgAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4xLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvDW2N/gAAIABJREFUeJzt3X94FNW9P/D3J/wIBAH5UYQAAVT4QtFii4itgBeqpljxIq01WGkULrZIW22h8HhrtVqqIGCLgqIF5EEtXPxWREViQVSqlgvEHxRraiwkpPxMAmJDAgRy7h+7s85uZnZndmd3fuz79Tz7PMnszOw5M+ecmc+cMzOilAIRERERERE5J8ftBBAREREREQUNAy0iIiIiIiKHMdAiIiIiIiJyGAMtIiIiIiIihzHQIiIiIiIichgDLSIiIiIiIoc5FmiJyK0i8rZT6yPniEiFiFzldjrIGtYlyrQgthFBzJOGbYR3sdwROScI9Yk9WjYEYYcTeQHrEhGZYftAREHBQMshItLS7TSQs7hP3cHtzm1AZIZ1g/wiiGU1iHlKt6QCLRHpLSIviEi1iNSKyGLddwtE5JiI7BWRsbrpHUVkuYgcFJH9IjJHRFrovp8sIh+Hl31NRPqEp4uI/E5EjojI5yLyNxG5KPxdbvj39onIYRFZKiJtk98ccfP8DIACAC+LSJ2IzBIRJSJTRGQfgC3h+S4XkXdF5DMR+VBE/sPqNkizS0Rkl4gcF5H/EZE24TRNFZFPReSoiLwkIvnh6X3D+YtUKhF5U0T+K/z3hSLyVnh9NSLyP7r5BorIpvA6/yEi38tQHqMYlVMRuUBEtoT/rxGR50TkXN0yFSIyW0R2ATiR7kaFdcmXdSkhP5Q9A0FsI3yfp2xrIwLSPrDc+azcWd0G4v12PC6f5snf9UkpZesDoAWADwH8DkA7AG0AjABwK4BGAFPD80wDcACAhJdbB+DJ8DLdAGwH8MPwd/8J4FMAgwC0BHAPgHfD3xUCKAVwLgAJz9Mj/N3vALwEoDOA9gBeBvCQ3TzZyHsFgKvCf/cFoACsCuepLYCeAGoBXItQEHt1+P8vJdoG6fyE070dQH54W30M4EcAxgCoAfA1ALkAHgOwNSZ/LXXreRPAf4X/Xg3gl+F8tgEwIjy9HYAqALeF9+VXw7/x5XTn02I5vTC8X3IBfAnAVgC/j9lWHwDoDaCtS2lkXfJoXQpK2TPZH4FqI4KQpzhl6VYEuI2Aj9sHljv/ljuL28Cz7XgQ8xSI+pREpr8OoFqfgfD0WwF8qvs/L5zR7gDOA3BKv4MATATwRvjvjQCm6L7LAVAPoE94Y34C4HIAObp5BMAJABfEpG1vmnd4bON/vu772QCeiVnmNQDFibZBBgrqLbr/HwawFMByAA/rpp+DUCPa10JBXQXgKQC9Yn7rJgB/iZn2JID70p1PK+XUYL7xAN6P2VaT3Uwj65J361JQyp7J/ghUGxGEPJmVJQS8jYCP2weWO/+WOyvbwGA+z7TjQcxTEOpTMkMHewOoVEqdMfjukPaHUqo+/Oc5CFWkVgAOhrv5Pwsnvlt4nj4AFum+O4pQBeuplNoCYDGAJQCOiMhTItIBoag7D0CpbrmS8PRMqtL93QfAjVp6wmkaAaAHEm+DdDuk+7seof2SD6BSm6iUqkPoqmBPC+ubhdA+2i4iH4nI5PD0PgCGx2yD7yPUEGeSYTkVkfNEZE14WMPnAJ4F0DVm2SpkButSNL/UpUT8UPaMBLGN8Hue2EZ8wU/tA8ud/8udX9vxePyaJ1/Xp2TGWVYBKBCRliaV0GyZUwC6mixTBeC3SqnnjBZWSj0K4FER6QZgLYBfALgPQAOAwUqp/XYzkSSVYFoVQlfZpsbOJCI9EH8buOEAQgULACAi7QB0AbAfoatIQKiR+zz8d6SwKaUOITR8ACIyAsBmEdmK0DZ4Syl1ddpTH59ZOX0QoX12sVLqqIiMR6iB1zPaz5lMY6JlWJe8V5f0/FD2rApiG+GnPGVrGxHE9oHlzvvlTi9I7bgmSHnyTX1KpkdrO4CDAOaKSDsRaSMiV8RbQCl1EMCfASwUkQ4ikiOhm++uDM+yFMDdIjIYiNxQeWP472EiMlxEWiG08U4CaFJKNQH4A4DfhSsmRKSniBQmkSerDgM4P873zwIYJyKFItIivG3+Q0R6WdgGblgN4DYRuUREchGqbP+rlKpQSlUjVGBvCedlMoALtAVF5EYR6RX+9xhClbAJwCsABojIJBFpFf4ME5FBGc2ZeTltD6AOwHER6YlQY+4W1iVzfqtLen4oe1YFsY3wU56ytY0IYvvAcuf9cqcXpHZcE6Q8+aY+2Q60lFJnAYxD6Oa5fQD+hdC4xkR+AKA1gL8jlLH/j1A3P5RS6wDMA7BGQt2WuwFoT7LpgFBFO4ZQN2EtgPnh72YjdHPltvBymwH8P7t5suEhAPdIqDvxu7FfKqWqELrh878RGgdbhVCB1baz6TZwg1JqM4BfAfgTQpXvAgBFulmmIpT+WgCDAbyr+24YgP8VkTqEblS9Uym1Ryn1bwDXhNdzAKEu33kI3ayYMXHK6f0I3Tx5HMAGAC9kMl0W05gI65LH6pKeH8qeVUFsI/yUpyxuIwLXPrDc+aLcRQSpHdcEKU9+qk/ak2KIiIiIiIjIIXxhMRERERERkcMYaBERERERETmMgRYREREREZHDGGgRERERERE5zNZ7tLp27ar69u2bpqQ4r6KiAjU1NRJvnqDlKWj5AZgnL2Ce/MGNPJWWlmLo0KGOrS9WNu4nv+UHAEpLS2uUUqYvkvVbnrKx3AHMkxcwT/5gJU+AzUCrb9++2LlzZ/KpyrBLL7004TxBy1PQ8gMwT17APPlDpvMkEjrGlJaWRqY5/SRbN/aTiDieD72gteMAICKV8b73W57YPvgD8+QP2ZongEMHiYgoBUqpyAf4IvjyKy39fs8HERG5LyOBloik7UNE5HVKKQwaNCjSbt18881uJyllRr0+WsDl1/ZZS7M+aPRjPoiIyBvSHmhpB2OnP1u3bk1rmhnURcv2/BPZpW87cnJy8Pzzz0farxEjRkSm+1GioXX6gMtvtHzpjzc8DhARUTLSepTXH4ydPFCJCEaNGpXyeuKJDeyylbbPsnkbeNW0adPY2+uyRYsWmW7/EydORLUhF110UWS5O+64A0optG7d2nf7yk56/dS7FS+NsUMjjeb1Qx6JiCiz0hJo/fOf/0zp5Fx/svLaa69Fpj/22GNRJzDpYnYlNhtPYv06hOayyy4zPQGeP3++rXV5Ie/vvfdes3wMGDDAtMe3vr4+Ml9FRYWrac+UTAWc+m1bXl5uug/y8vISruvkyZNoampyvXxZFTu0zgo/tCFW82XWy+XVfBERkbtsPXXQiu3bt2P48OGGY/eTUVhYCCC5A3yq9MFi7O+6kR63+O0m90T7RkTw/vvv449//KOldenzn+n9reWlZcuWtn67bdu2hvstqOU13j53sq7efvvt+MMf/uDodhQR1NTUeLrnONUyZBRseSWvyaZHP79f2kaiZP3qV7/CnDlzAACtWrXCqlWrUFRU5HKqiLzP8R4tfZBVVlYWd2hTTk4OZsyY0WwdRk+xmjx5cuQq4rp165xOdhSjA2/sgdQrJwmZ4pcTiS1btgCIv3+UUli9ejXuuuuuuOsSEUyYMCHyf7t27VBQUOBMQi3Iy8tD165doZRCY2Nj0uvR6pJ2Mu+XfWlVohNlJy8UOB1kabp06eL4OtMh1bx7LThxOujzQp7iqa+vR0NDg9vJIB/SgiylFGpra1FSUhL3/C4vLw9HjhxxOdVE7nM00Jo0aRKAL65ajh49GqdOnTIdWnPy5ElccMEFphW1c+fO+Nvf/gYAWL58OWprawEg6uQ3XbItkDKjv0fLD9vkm9/8pqV0KqUi99cY0ab/6U9/ikyrq6tDVVWVMwlNYO3atWhoaEB1dbVj6+zSpQuUUujUqZPnTwitMrsoko4LIzfddBMef/zxlNfjR0b32ib7iR1+57ZUy4Zf2scJEyagQ4cO6Nixo+m+yVT7ZlemhgVTfFqdbd++PVauXBn3gWWffvopevToARHBOeec43bSiVzjaKD17LPPRlW0gwcPonXr1qbzt27dOnJTuNFn9+7duPzyy6OW6dy5s5NJbsbLw3fc4pft8fnnn9ua3+xeCxHB7bffbpjvRYsW4fvf/75TSTZVXl6etnUfPXo0bet2g9EwZbOhvqlYu3Ytpk2blvJ6zOzatcvzJ4/xTqysfrzC69vaaSdPnsRbb72F06dPm+6bgoICjB8/3u2kRhgF57GjXRh4ZZbVCyT5+fk4e/YslFI4c+YM9w9lLU8/Wzg/Px8nTpyI/C8iOHr0KG677ba0/q5Rw52OEzevSHSQ8kteO3bsmPT9I7GfJ5980nDen/70p5bu7UrVL3/5SwBA//79bS8b9JMOsxMr7X+jvHvpBN/MxRdfHHkwRuxn3rx5bicvkPQXWpJhdGHOq3WvpqYGHTt2jDuPUgrr16/PUIqsiTck2CzwovR68MEHE25n/b44efIkzp49CxHBVVddlYkkOur++++31Fs/btw4PPXUU3jmmWcwb948TJw4EU888YTbySeXeTrQiqX1Zq1YsSJtv6Fv1M3u7XB6XL+bEvXgee0qtNvmzp2L6dOnZ+S3tOEXdogIbrnlFjQ2NpoeCNesWeNE8lxlNPxMK6d+Lq9mV++rqqoiB/OvfOUrbiczUIx6tq0wC+hTDd7SZceOHVGvGABCebj00kujpnllSKddPFZlzt133x15NYVRWd+/fz/69OkDIPSANADIycmBUgqvv/6678rXr3/9a0u99T/72c+wd+9e7Ny5EwBQXFyMuXPn4s4773Q5B+Zig8UdO3a4naTAcfypg3pnz55Fy5bRP5FqQ5iphtQoyIrXw+VHsUGW9n/Q8umku+++O6PbRNsf2m9+9NFHkZOl2HS89NJLAIBnnnkm7jonTpwYqP1qlJegDQFevHgxFi9eDAAYPXp04PLnBbG9Ila2b7zeFq+fTBq195rYdsctPB55x1NPPYXp06djyZIlAIBTp05FfS8iKC0txde+9jX07NkTlZWVhuVIqdD9+SKC3bt3Y/DgwRnNRzqNGTMGY8aMiZpWWVkJEcGiRYtcSpUxrV7V1tZG3ZIzaNAglJWVRf4vLi7GypUrM528QElrj5b2SGrt89xzzzl68Jk0aVJkiJVT9MOPjIKsoFw1i90PsYFlbG9Btom9eR8IPdLWDd27d4+8k6m4uBh///vfDee7/vrrAQCzZ8/G6dOnDefp1asXrrnmmvQk1EWxwwbTUUdvuOEGvPLKK46v16433ngDJ06cyNq6mW5mIxn0rAQhfj9OtGzZEj169HDt943uz7K7rBd7FuMxGo7mFVOnTm32MCB9GpVSGDp0KA4fPgwgdHFIRFBfX99sXW3atIFSoZe4eymP2UDbZ1VVVVBKNXvuwccffxxV57Snhwft3u5McjzQampqMv1u5cqVyMlx7idXrVqFBx980LH1Acbjvr14I7cTYvMTxDza1atXr8g9MUopFBUVIScnJ+qAn2kHDx5EQ0MDmpqaUFpaii9/+cum8yql8PDDDyM3N9cwrfv37496CbhfxZ6MxBs2aKeHIp61a9di3LhxKa3DKVZehuwXXjnRMjq5TfVk1yt5MxOvXjQ2NuLQoUMZTlHq71ozu3fLL2LT77WAS6OdfMcO3+7evTsAYPr06VBKoW3btqbrUErh8ccf92T+NDt37sTw4cPdTkbKtHJ08uRJKKXQq1cvS8tt27YNSil06dLF0/vJyxwNtG688Ub8+c9/jvy/c+dOiAgeeeQRvPrqq9i0aRPOnj1ruOypU6fw9ttvm+7IBQsWOJnUrGalsmRjhRIR7N+/H0opzJo1CwCwevXqyMH6zJkzrqVNKYUWLVrg8ssvTxjwmX0vIp7okXGC1aDXyR6u2GHQemYPsUhUj1K5gr1u3bq4T3X1A69d2DG6wAaYB/axvNobcfz48WZlxUodynTPqdUeLDtp8loZM2NWrrwacM2aNQuXXHIJAKCiogK5ubkA7A+bnTZtWmSZVatWpSWtqbjrrrvw6KOPprSOzp0748MPP3QoRdZpT3sUETQ2NkIpFdlPdnm1HPqBo4HWlVdeiXfeeSfy/9ChQ6GUwoEDB/DII4/EPTi1adMGDz30kOm6f/GLXziZ1Kxn5yQ1m7z88suG09977z2MGDEiw6mJppTCtm3bUlrHt7/9bYdS4x6jnli92BPddJ9oiQhatGhheoO0WT3SLjoZzW/lYDh+/PiUXmRN1pj1kJgFyV4cAfHzn/8cTz/9tO3lMtlzajZs34iXtq0TrBxrY8ue2+bNm4d9+/ZBRNC3b9+oe7a0dszOcDOlFIqLizFy5Mh0JDdp77zzDi677LKU1lFbWxsJStNNH1y1atUq0hbFu1Boh/445dQ6g87RQGvIkCEoLS1tNn3BggXYvHmz4TIigg8++ABKKWzYsMH2bxYXF+P555+3vVy2sjqEKmgHskS0A9d1111n+H11dXXcIRCZcuzYsaQOstqQgSDK5MlubOD0r3/9KzLdLu0eVqPfMLvHjtLDap2K7XEx+njRihUrcPPNN7udjLjStQ29EJRYYfW4bCXYz5R4+0wbbnbeeefZWl+8kU1+V1xc3OyF4U7TB1fpbI/8OCzXLY4GWhdeeKHt7lGlFC655BJ06dIlqZcRT5w4kYGWRXYqhN8qjxMvko33CNbCwkJs2rQp5d9I1bnnnov+/fsntX+SHTLgZbEHlES9SE79pohgyJAh6N27t2sn13PnznXld4PMK70FlD2SuX/UL0G+UgpHjhyxPdTziiuuiDywIRNqampQWlpq+qApJyilMG7cOHzyySeWRjwkw4l7ke04c+YMVq5cyTYzAUf7/dq3b4/a2lrbyykVek9MixYtkJ+fb2vZAQMGYNeuXbZ/M1sl05uV6cprl1NDxH7/+98bTi8oKEhpvU775JNPICIoKyvDwIEDAQATJkzAunXroubTX3Hy8v7zI6VU5GXSBw4csN1umSkvL8eAAQMwZ84cLFu2zHCeqVOnRqWDUmfU5lFI//79UVlZGXkvkt94uR20W84yNRzaSUop3Hnnnba2/9tvvw0g/fm94YYb8OKLL6Jz58646KKLUF9fH3kHlsbJ3/7ud7/r2LpiJXPu7YTi4mLceuutrvy2X3hmgGXv3r2TWq5ly5ZpfUiBnxq0eLx4kEnV6dOnkZubiy1btmD06NEpr2/x4sX48Y9/HDVt0KBBkcegeol2JUxL17p16yJ/jxkzBv/+978BADNnznQtjUFXXl6Op59+Gj179kw4r9kJVez0iy++GEDo4QXHjx83XMaN+1WzLfDwWn2n4Ip377rZvH47ni9atAi33HKL7XQrpfDXv/41bfl98cUXfbUd4+natWvCvNTX16Ndu3ZR07p3746DBw+m9Nux5yMUzTOBFqWPEydJXqtEJSUlGDt2bORpb6nQnnb0gx/8AD/5yU+igpeysjJP5VuvsLAQOTk5aGpqQn5+PkQE1157Ld54441ImhcuXOjZ9AfBbbfdhsmTJwMwPmGqqqpCQUGB4XcigjVr1kQes6sNl6mrq2t2MKT08GMPgV0igj179ridjJQkOv547fhkRbzjVhAvbAwbNgzV1dW299XXv/51iAimTJmC5cuXpzGF5vbv32/pgppbRASjRo2KO09BQYHhUMxDhw6hb9++qKioSPg71dXVKCwsjDxX4dChQ5F78PLy8iAijpyTpYs+XZlsLxy9R6tdu3bN3haebocOHfLc0C6vSrbwe238t4hg7NixKY9v1j+qedKkSVFjpkUERUVFnsp3rJKSkkj6tMfSX3/99VFXPUtKStxMYlZQSmHZsmWG9/eYBVnachs2bMCcOXMwZ84ciAj+8pe/eDLI8nI9SJbRgwWCql+/fpG/tbwOGDDA0rLl5eX47LPP0pU0U3YfGJAocPFSGTYL8M0e6BN7DDY69mWi/BYWFuLNN99sll6rTxfs2rUr6uvrTdOqPTFv/fr1UdObmpqwYsUKNDQ0JJ32ZGj5+8Y3vhH5205dsPKgkq1bt9p6YIjRbwDAW2+9ZTpPfX19ZGSO/jNlyhQAQGVlZcLfEBF069YN77//fqQsau9MA0KvglBKRd476jWx9SqTbb7jLyyOpb1Ly8lMlZSURNZXU1OTUiHNBvoHBZg9qcjqx20tWrQAYP3x9LEf/aNP6+rqTJ+WpJTK+EWDZDQ2Nkbtlx/+8IcAvniMe2FhoSvpyjZTpkyJOhl64IEHLJ3crVq1Chs3bkRJSQlmzpzp+isEzHih7qdL7I3pQc6riKB9+/ZQSqG8vDzhvFoZHjJkSIZSGGLnIQ/6euanfRfvAkyyQWG6g8knnngCEydOBAAUFRXhwgsvhFL2Xmbbtm1bnDp1ynB+7Yl548ePb/adUgp5eXkZeyKrVq6UUqisrIz83alTJ9vLK6XQoUMHwzyPHDkSR44cSSqNV199Ndq1a5dwv5vNs2zZMsuvcLD68BWlFF566SVPtKWx566xFyucfhiJmbQPHRw2bJjjjaATvRnZKtmG2CvbuqmpyXKQBXyR37q6OrRv3z7SkAeF2XssXn311UDl0y+0cnfllVfavhfBy7KlvY09VtndL17rOTGyfPlytGrVyvR7Lw6njL0HxKw3J7ac8t4RZ/Xr1w+HDh0CAKxZsybpk+nWrVtHhpjZbSczMTwtXrqslCkRwccffxw17fjx4xg4cKCj5dHKk5Dnz58f93vtpeT67dmjRw/s3bsXubm5+O1vfxt3+aVLl+JHP/pR1LRx48ZBKYVevXq5Uv/sDBHMRBuR9h4tIJTp/fv3O7KumpqayDoB4Nprr8Vzzz3nyLqzSbxeKq/1YmmsVoZ9+/Y1m3bOOecE9mAbe3KRzScWbpdZ7SqZfngN+U8qFwe91HZeddVVzZ5G+r3vfQ/r1683HbbmtaHiGrMeR6NhdZm8Wp1uVvLgVj7t9jzq959W1vRp37NnD0Qkct+r2W/m5KTv1DUvLw/33ntvyuvRngisV1ZWZtqzlQxte44cORIvvPCC4TyzZs2yVJ/1+3Hr1q1o06YNRAT33HNP3OWmTZtmOgLqscceS2tbYva7VsukJt1tRdp7tJRS2Lt3L6644go0NTWlvD79k1VEBDk5OWmtdEFjdLXPjNHVQT/QHkMcm957770XgwcPdiNJGSMiGD58uNvJcIVfyif5g/44k0zvpBdO8l9//XVs3rw58r9RPrzYg2XGbo+jl/MUW67MyouVAMbKfF6glMKsWbMwcOBAlJWVRaZp26Jfv36Wg4J0XVBsaGjA/fffn/TyidJ1/PjxqH197NixpH9L+50dO3ZgyZIl+M53vpP0uvS0IaGaROeJbnBy/8cG/07LSITSr18/VFRUOHrg0dZ19uxZx9aZbRLtDy+cKDjpN7/5DXbv3u12MtJCO/CMHj0a27Ztczs5RLZ4ua2xe7XTzsUsN40dOxYigurqal+cpMfyY5o1sT1uqQ5V9fq2eOWVVyJ/z58/PxJkaZKpJ6+99ppn65ZVIoIuXbqkvP+GDRuGlStXGt5HdfjwYYhIs20OhM7Nkw0ubrrpJixYsCCldCfL6kUKO+vy/dBBJ6xevRoAMHv2bIgI/vGPf3i+cfE6P18NTCQ27UuXLnUpJZmjlMKWLVvcTgaRLX5oZ+ycCHo5uAJCFydFBJs2bYJSCl27dnU7SQQ0O3E0+ui/i13Gy6677joAobS/++67hvPYrTfXXHNNyulavXp13G1sZT+ksnwy+barW7duUEph0KBBzdIxevTopMvQ2rVrMWPGDIdTm5jTPVmZqEO+eY9WUVGR7xoXr7Jasb18smDGKM0sN0SUKrsnRF5sb9gWepNZ2TK7au/H/ZcozVrgb+fkN9UgpaioCEVFRVHTEv3+Bx98gK9+9aum8yRaPlMn97FS+U2j7XzHHXekmiTbzLZdMkNJM7kf0tKjlSiaFxEcPnzY9jr90EXuB4nGo9q5wdWL6urqospaXV2d20kiogCKd6VaP80NDzzwABYuXBiVFr+26UGmD36t3I/lhf3X2Njo+DpnzpxpuUdI/xk6dKjjaRk2bJjpd/GCrEQy9Wj6dIg9L1yyZElGf99K2bfagZDpeuR4oGU0RjT2c+bMGeTn51uuSHv27PFE4xIERkFU7ImC32zcuDGq8mjvjNA+Vt4zQUSps3OC5Nd2R59uK8c7t9qe7du3Y8aMGQywPMzsQqed+TNNKYXWrVtDRJCfn5/0ej766KOourRr166o33Crbimlot7/2q9fP9x3333o1KkTRMTSbQgTJkwwnJ6bm+uJfeg3VgIjqxcqtHkzyZWhgy1atOBDLDxGH3R5tSEwGyZw/vnnezbNREFiJSgKcl30S95mzJiBDRs2YOPGjfjWt77ldnIoAb9dbNDqwdatW5NOe0FBARobG03fBekmLX/awx7atm2L3bt3o2fPnpaW1V9AGjx4MHbv3g0RQUNDQ/oSHUBOBUZuD5n2XgmnjPJyYGXET2klChLWPf9YuHBhZNggeZtRvfJL4DVq1KhAtwszZ85Majn9Njlz5gxEBEeOHEGbNm2cSlrWyFSQlc46x0CLIvzSuBMRERF5XcuWLQMdjKZbMuel+tFPVrZ9ujscGGgRAPe7VomIiKg5XgSlbJTMLS12H3aRiVFdvnmPFqUXAywiIiJv4jGayBovBVkAe7SyitlVMf10XjkjIiI/CPrxKuj5I3JDpkdwMdDKErwaRkREQRHk4e5BzBORF7jRbjDQIiIiIt9gIEJEduh7h7PiPVpERERERETp4maApWGgRUREREREgeN2DzifOkhERERERJ5jJ1CKndftIAsAxE4iRKQaQGX6kuO4PkqpL8WbIWh5Clp+AObJI5gnf2Ce/CFo7TgQvDxlXbkDmCePYJ78IWGeAJuBFhERERERESXGoYNEREREREQOY6BFRERERETkMAZaREREREREDmOgRURERERE5DAGWkRERERERA5joEVEREREROQwBlpEREREREQOY6BFRERERETkMAZaRERWOe2HAAAAC0lEQVREREREDvs/3vNXia/MIw0AAAAASUVORK5CYII=\n",
       "text/plain": [
        "<Figure size 1080x108 with 16 Axes>"
       ]
@@ -601,44 +679,51 @@
    "source": [
     "```python\n",
     "# Choose the hyperparameters and specify the domain\n",
-    "optimizer_id_to_name = {1: 'sgd', 2:'adam'}\n",
-    "domain_with_2_hyperparams = [{'name': 'learning_rate', 'type': 'continuous', 'domain': (0,1)},\n",
-    "                              {'name': 'optimizer', 'type': 'discrete', 'domain': (1,2)}]\n",
+    "from emukit.core import CategoricalParameter\n",
+    "p1 = ContinuousParameter('learning_rate', 0, 1)\n",
+    "p2 = CategoricalParameter('optimizer', OneHotEncoding(['sgd', 'adam']))\n",
+    "space_with_two_params = ParameterSpace([p1, p2])\n",
     "\n",
-    "# Override this method to extract the optimizer in addition to learning_rate from GPyOpt config\n",
+    "# Override this method to extract the optimizer in addition to learning_rate from emukit config\n",
     "def get_hyperparameters_from_config(config):\n",
     "    \"\"\" \n",
-    "    Extract hyperparameters from input configuration provided by GPyOpt.\n",
+    "    Extract hyperparameters from input configuration provided by emukit.\n",
     "    Refer the caller 'hpo_objective_function' for more details.\n",
     "    \"\"\"\n",
-    "    learning_rate = map_learning_rate(config[0]) # Map learning_rate value given by GPyOpt to the desire range\n",
-    "    optimizer = optimizer_id_to_name[config[1]]  # Using optimizer given by GPyOpt\n",
+    "    learning_rate = map_learning_rate(config[0]) # Map learning_rate value given by emukit to the desire range\n",
+    "    optimizer = p2.encoding.get_category(config[1])  # Using optimizer given by emukit\n",
     "    return optimizer, learning_rate\n",
     "\n",
-    "# Initialize GPyOpt with new domain and run optimization\n",
+    "# Initialize emukit with new domain, create the model and run optimization\n",
     "set_random_seeds()\n",
-    "hyperparameter_optimizer2 = GPyOpt.methods.BayesianOptimization(f=hpo_objective_function,\n",
-    "                                                                domain=domain_with_2_hyperparams, \n",
-    "                                                                initial_design_numdata=5)\n",
-    "hyperparameter_optimizer2.run_optimization(max_iter=5)\n",
+    "\n",
+    "X = np.array([[0.8] + p2.encoding.get_encoding(DEFAULT_OPTIMIZER)])\n",
+    "Y = np.array([[1.0 - precision_default]])\n",
+    "gpy_model = GPy.models.GPRegression(X, Y)\n",
+    "\n",
+    "emukit_model = GPyModelWrapper(gpy_model)\n",
+    "hyperparameter_optimizer2 = BayesianOptimizationLoop(space_with_two_params, emukit_model)\n",
+    "\n",
+    "hyperparameter_optimizer2.run_loop(hpo_objective_function, NUM_ITERATIONS_TO_RUN)\n",
+    "results = hyperparameter_optimizer.get_results()\n",
     "\n",
     "# Take hyperparameters that minimized the objective function output\n",
-    "x_best2 = hyperparameter_optimizer2.X[np.argmin(hyperparameter_optimizer2.Y)]\n",
-    "optimized_learning_rate2 = map_learning_rate(x_best2[0])\n",
-    "precision2 = 1.0 - min(hyperparameter_optimizer2.Y)[0]  # Objective was to minimize 1-precision \n",
+    "x_best2 = results.minimum_location\n",
+    "best_learning_rate = map_learning_rate(x_best2[0])\n",
+    "best_optimizer = p2.encoding.get_category(x_best2[1:])\n",
+    "precision2 = 1.0 - results.minimum_value  # Objective was to minimize 1-precision \n",
     "print('Optimized learning rate: {}. Optimizer: {}. Precision on validation data: {}'\n",
-    "      .format(optimized_learning_rate2, optimizer_id_to_name[x_best2[1]], precision2))\n",
+    "      .format(best_learning_rate, best_optimizer, precision2))\n",
     "\n",
     "# Train neural network with optimal (learning rate, optimizer) and get predictions on test data\n",
     "# Along with training data, validation data is also used to train the final model\n",
     "predictions2 = train_and_predict(source_model=source_model, \n",
     "                                   train_data_iterator=train_validation_iterator,  # train on (train + validation) set\n",
     "                                   test_data_iterator=test_iterator,  # predict on test data\n",
-    "                                   optimizer = DEFAULT_OPTIMIZER,\n",
-    "                                   optimizer_params = {'learning_rate': optimized_learning_rate2})\n",
+    "                                   optimizer = best_optimizer,\n",
+    "                                   optimizer_params = {'learning_rate': best_learning_rate})\n",
     "precision_optimized2 = np.mean(predictions2 == test_labels)\n",
-    "print('Optimized learning rate: {}. Optimizer: {}. Precision on test data: {}'\n",
-    "      .format(optimized_learning_rate2, optimizer_id_to_name[x_best2[1]], precision_optimized2))\n",
+    "print('Precision on test data after optimization: ' + str(precision_optimized2))\n",
     "show_predictions(predictions2, test_images, id2label)\n",
     "```"
    ]
@@ -646,9 +731,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": []
   }
@@ -669,7 +752,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* We are phasing out gpyopt in favor of emukit. This PR replaces gpyopt with emukit in xfer-hpo notebook.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
