### PR TITLE
Added .gitattributes to mark xfer as Python 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ipynb linguist-language=Python


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Currently, github linguist classifies xfer as a whole to the "Jupyter notebook" category. This could be simply because the notebooks are very big (since they contain images etc). However, marking the repo as "Python" language seems more accurate. 

Therefore, I created a .gitattributes to mark notebook files as Python, which overall leads to a classification as Python for the whole project. Another option would be to exclude ipynb files from linguist, but since these notebooks are Python anyway I think it makes sense to mark them as Python. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
